### PR TITLE
cleanup: replace ODF with OCO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ go-test: ## Run go test against code.
 
 test: test-setup go-test ## Run go unit tests.
 
-ODF_OPERATOR_INSTALL ?= true
-ODF_OPERATOR_UNINSTALL ?= true
+OCO_OPERATOR_INSTALL ?= true
+OCO_OPERATOR_UNINSTALL ?= true
 e2e-test: ginkgo ## TODO: Run end to end functional tests.
 	@echo "build and run e2e tests"
 

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -69,8 +69,8 @@ FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 
 # manager env variables
-OPERATOR_NAMESPACE ?= openshift-storage
-OPERATOR_CATALOGSOURCE ?= odf-catalogsource
+OPERATOR_NAMESPACE ?= ocs-client-operator-system
+OPERATOR_CATALOGSOURCE ?= oco-catalogsource
 
 # kube rbac proxy image variables
 CLUSTER_ENV ?= openshift


### PR DESCRIPTION
replacing ODF with OCO (ocs-client-operator) and replacing openshift-storage with ocs-client-operator-system namespace as that is the one used in yaml files.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>