### PR TITLE
bundle: enable bundle generation for fusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	cd config/manifests/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)" && \
 		$(KUSTOMIZE) edit add patch --name ocs-client-operator.v0.0.0 --kind ClusterServiceVersion\
 		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) --extra-service-accounts=ocs-client-operator-csi-cephfs-provisioner-sa,ocs-client-operator-csi-cephfs-plugin-sa,ocs-client-operator-csi-rbd-provisioner-sa,ocs-client-operator-csi-rbd-plugin-sa,ocs-client-operator-status-reporter
+	$(KUSTOMIZE) build $(MANIFEST_PATH) | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) --extra-service-accounts=ocs-client-operator-csi-cephfs-provisioner-sa,ocs-client-operator-csi-cephfs-plugin-sa,ocs-client-operator-csi-rbd-provisioner-sa,ocs-client-operator-csi-rbd-plugin-sa,ocs-client-operator-status-reporter
 	sed -i "s|packageName:.*|packageName: ${CSI_ADDONS_PACKAGE_NAME}|g" "config/metadata/dependencies.yaml"
 	sed -i "s|version:.*|version: "${CSI_ADDONS_PACKAGE_VERSION}"|g" "config/metadata/dependencies.yaml"
 	cp config/metadata/* bundle/metadata/

--- a/config/manifests/fusion/kustomization.yaml
+++ b/config/manifests/fusion/kustomization.yaml
@@ -1,0 +1,32 @@
+resources:
+- ../bases
+- ../../default
+- ../../scorecard
+
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/icon
+      value:
+      - base64data: >-
+          PHN2ZyBpZD0iU3BlY3RydW1GdXNpb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSI5ZjVmbzEweDdiIiB4MT0iNS45MjUiIHkxPSIxNi41NDkiIHgyPSIyNC4xNjUiIHkyPSI2LjAxOCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI2ZmZiIgc3RvcC1vcGFjaXR5PSIwIi8+PHN0b3Agb2Zmc2V0PSIuNDUiIHN0b3AtY29sb3I9IiNmZmYiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0ic2F1bmxlajA2YSIgeDE9IjIwLjQ5MyIgeTE9IjI4IiB4Mj0iMjAuNDkzIiB5Mj0iNyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iLjU1IiBzdG9wLWNvbG9yPSIjZmZmIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjZmZmIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iZ284Mms5Mm4zYyIgeDE9IjMuNDE5IiB5MT0iMTQuMDA3IiB4Mj0iMjEuNjA1IiB5Mj0iMjQuNTA3IiB4bGluazpocmVmPSIjc2F1bmxlajA2YSIvPjxsaW5lYXJHcmFkaWVudCBpZD0iam01MDRta2c0ZSIgeDE9Ii0yOTQ2IiB5MT0iLTQ5ODYiIHgyPSItMjkxNCIgeTI9Ii01MDE4IiBncmFkaWVudFRyYW5zZm9ybT0ibWF0cml4KDEgMCAwIC0xIDI5NDYgLTQ5ODYpIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIuMSIgc3RvcC1jb2xvcj0iIzhhM2ZmYyIvPjxzdG9wIG9mZnNldD0iLjkiIHN0b3AtY29sb3I9IiNlZTUzOTYiLz48L2xpbmVhckdyYWRpZW50PjxtYXNrIGlkPSI5bHhiamJ0dTZkIiB4PSIwIiB5PSIwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiPjxwYXRoIGQ9Ik0yNCAxNmgtMlY2LjU4bC02LTMuNDI3LTEzLjM1NiA3LjcxMy0xLTEuNzMyIDEzLjg1Ni04YTEgMSAwIDAgMSAxIDBsNyA0QTEgMSAwIDAgMSAyNCA2eiIgc3R5bGU9ImZpbGw6dXJsKCM5ZjVmbzEweDdiKSIvPjxwYXRoIGQ9Ik0yMSAyOGEuOTkyLjk5MiAwIDAgMS0uNS0uMTM0bC04LjUxMy00LjkxNSAxLTEuNzMyTDIxIDI1Ljg0N2w2LTMuNDI3VjdoMnYxNmExIDEgMCAwIDEtLjUuODY4bC03IDRBMSAxIDAgMCAxIDIxIDI4eiIgc3R5bGU9ImZpbGw6dXJsKCNzYXVubGVqMDZhKSIvPjxwYXRoIGQ9Im0xNy4zNTYgMzEuODY2LTEzLjg1Ni04QTEgMSAwIDAgMSAzIDIzdi04YTEgMSAwIDAgMSAuNS0uODY2bDguNTY3LTQuOTQ2IDEgMS43MzJMNSAxNS41Nzd2Ni44NDZsMTMuMzU2IDcuNzExeiIgc3R5bGU9ImZpbGw6dXJsKCNnbzgyazkybjNjKSIvPjwvbWFzaz48L2RlZnM+PGcgc3R5bGU9Im1hc2s6dXJsKCM5bHhiamJ0dTZkKSI+PHBhdGggdHJhbnNmb3JtPSJyb3RhdGUoLTkwIDE2IDE2KSIgc3R5bGU9ImZpbGw6dXJsKCNqbTUwNG1rZzRlKSIgZD0iTTAgMGgzMnYzMkgweiIvPjwvZz48cGF0aCBkPSJNMTYgMjAuNDY0YTEgMSAwIDAgMS0uNS0uMTM0bC0zLTEuNzMyYTEgMSAwIDAgMS0uNS0uODY2di0zLjQ2NGExIDEgMCAwIDEgLjUtLjg2NmwzLTEuNzMyYTEgMSAwIDAgMSAxIDBsMyAxLjczMmExIDEgMCAwIDEgLjUuODY2djMuNDY0YTEgMSAwIDAgMS0uNS44NjZsLTMgMS43MzJhMSAxIDAgMCAxLS41LjEzNHptLTItMy4zMDkgMiAxLjE1NCAyLTEuMTU0di0yLjMxbC0yLTEuMTU0LTIgMS4xNTR6IiBzdHlsZT0iZmlsbDojMDAxZDZjIi8+PC9zdmc+
+        mediatype: image/svg+xml
+    - op: replace
+      path: /spec/maintainers
+      value:
+      - email: mysphelp@us.ibm.com
+        name: IBM Support
+    - op: replace
+      path: /spec/provider/name
+      value: IBM
+    - op: replace
+      path: /spec/links
+      value:
+      - name: Source Code
+        url: https://github.com/red-hat-storage/ocs-client-operator
+    - op: replace
+      path: /spec/displayName
+      value: Fusion Data Foundation Client
+  target:
+    kind: ClusterServiceVersion
+    name: ocs-client-operator.v0.0.0

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -33,6 +33,13 @@ REPLACES ?=
 # but can skip several. This can be accomplished using the skipRange annotation:
 SKIP_RANGE ?=
 
+# Set to true for generating fusion bundle
+FUSION ?= false
+MANIFEST_PATH=config/manifests
+ifeq ($(FUSION), true)
+MANIFEST_PATH=config/manifests/fusion
+endif
+
 # Image URL to use all building/pushing image targets
 IMAGE_REGISTRY ?= quay.io
 REGISTRY_NAMESPACE ?= ocs-dev


### PR DESCRIPTION
This PR adds a kustomization file to patch the base CSV with content for fusion bundle. It overwrites the default bundle and reuses default Dockerfiles for bundle generation and build. We do not commit these updated changes to git.