### PR TITLE
Fix bugs found in migration of ODF to ocs-client-operator

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -639,10 +639,10 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 256Mi
                   requests:
                     cpu: 10m
-                    memory: 64Mi
+                    memory: 256Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                 volumeMounts:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,10 +62,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 256Mi
       volumes:
       - name: csi-images
         configMap:

--- a/controllers/storageclassclaim_controller.go
+++ b/controllers/storageclassclaim_controller.go
@@ -347,14 +347,7 @@ func (r *StorageClassClaimReconciler) reconcilePhases() (reconcile.Result, error
 
 				if resource.Name == "cephfs" {
 					csiClusterConfigEntry.CephFS = new(csi.CephFSSpec)
-					subVolumeGroupName := data["subvolumegroupname"]
-					// In ODF 4.12 the subvolume group name is not passed in
-					// the GetStorageConfig RPC call, so we need to generate it
-					// here as this is expected to work with ODF 4.12
-					if subVolumeGroupName == "" {
-						subVolumeGroupName = fmt.Sprintf("cephfilesystemsubvolumegroup-storageconsumer-%s", r.storageClient.Status.ConsumerID)
-					}
-					csiClusterConfigEntry.CephFS.SubvolumeGroup = subVolumeGroupName
+					csiClusterConfigEntry.CephFS.SubvolumeGroup = data["subvolumegroupname"]
 					// delete groupname from data as its not required in storageclass
 					delete(data, "subvolumegroupname")
 					storageClass = r.getCephFSStorageClass(data)


### PR DESCRIPTION
This PR contains two fixes
* Increase the resource limit to fix the OOMKilled problem
* remove the code which generates the subvolumegroup name if its present in the RPC call.