### PR TITLE
bundle: hide operator from the operatorhub

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
-    operators.operatorframework.io/operator-type: standalone
+    operators.operatorframework.io/operator-type: non-standalone
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: ocs-client-operator.v4.12.0
   namespace: placeholder

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ocs-client-operator.clusterserviceversion.yaml
 commonAnnotations:
   olm.skipRange: ""
-  operators.operatorframework.io/operator-type: standalone
+  operators.operatorframework.io/operator-type: non-standalone
 patches:
 - patch: '[{"op": "replace", "path": "/spec/replaces", "value": ""}]'
   target:


### PR DESCRIPTION
This operator is not supposed to be directly installed from the operator hub, and the agent is supposed to install it, Hiding the operator from the operator hub for the same reason.