### PR TITLE
remove non-standalone annotation

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,6 @@ metadata:
     console.openshift.io/plugins: '["odf-client-console"]'
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
-    operators.operatorframework.io/operator-type: non-standalone
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: ocs-client-operator.v4.12.0
   namespace: placeholder

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
 - ocs-client-operator.clusterserviceversion.yaml
 commonAnnotations:
   olm.skipRange: ""
-  operators.operatorframework.io/operator-type: non-standalone
 patches:
 - patch: '[{"op": "replace", "path": "/spec/replaces", "value": ""}]'
   target:


### PR DESCRIPTION
remove non-standalone annotation from the CSV so that the operator can be visible in the UI.


