### PR TITLE
csi: add csi-addon sidecar to the rbd provisioner deployment

### DIFF
--- a/pkg/templates/csisidecars.go
+++ b/pkg/templates/csisidecars.go
@@ -143,6 +143,67 @@ var SnapshotterContainer = &corev1.Container{
 	},
 }
 
+var CSIAddonsContainer = &corev1.Container{
+	Name: "csi-addons",
+	Args: []string{
+		"--node-id=$(NODE_ID)",
+		"--v=5",
+		fmt.Sprintf("--csi-addons-address=%s", DefaultCSIAddonsSocketPath),
+		fmt.Sprintf("--controller-port=%v", DefaultCSIAddonsContainerPort),
+		"--pod=$(POD_NAME)",
+		"--namespace=$(POD_NAMESPACE)",
+		"--pod-uid=$(POD_UID)",
+		fmt.Sprintf("--stagingpath=%s", DefaultStagingPath),
+	},
+	Ports: []corev1.ContainerPort{
+		{
+			ContainerPort: DefaultCSIAddonsContainerPort,
+		},
+	},
+	EnvFrom: nil,
+	Env: []corev1.EnvVar{
+		{
+			Name: "NODE_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name: "POD_UID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.uid",
+				},
+			},
+		},
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+	},
+	VolumeMounts: []corev1.VolumeMount{
+		{
+			Name:      "socket-dir",
+			MountPath: DefaultSocketDir,
+		},
+	},
+	ImagePullPolicy: corev1.PullIfNotPresent,
+}
+
 var DriverRegistrar = &corev1.Container{
 	Name:            "csi-driver-registrar",
 	ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/templates/defaults.go
+++ b/pkg/templates/defaults.go
@@ -21,9 +21,14 @@ const (
 	DefaultKubeletDirPath        = "/var/lib/kubelet"
 	DefaultProvisionerSocketPath = "unix:///csi/csi-provisioner.sock"
 	DefaultPluginSocketPath      = "unix:///csi/csi.sock"
+	DefaultCSIAddonsSocketPath   = "unix:///csi/csi-addons.sock"
 	DefaultSocketDir             = "/csi"
+	DefaultStagingPath           = "/var/lib/kubelet/plugins/kubernetes.io/csi/"
 
 	// configmap names
 	MonConfigMapName        = "ceph-csi-configs"
 	EncryptionConfigMapName = "ceph-csi-kms-config"
+
+	// default port numbers
+	DefaultCSIAddonsContainerPort = int32(9070)
 )


### PR DESCRIPTION
RBD Provisioner was missing csi-addons sidecar, adding it in this PR

Ref for CSI-Addons Sidecar: [container config](https://github.com/rook/rook/blob/master/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml#L140-L180)