### PR TITLE
store desired subscription channel as annotation on storageclient CR

### DIFF
--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -73,3 +73,17 @@ func AddLabels(obj metav1.Object, newLabels map[string]string) {
 	}
 	maps.Copy(labels, newLabels)
 }
+
+// AddAnnotation adds an annotation to a resource metadata, returns true if added else false
+func AddAnnotation(obj metav1.Object, key string, value string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+		obj.SetAnnotations(annotations)
+	}
+	if oldValue, exist := annotations[key]; !exist || oldValue != value {
+		annotations[key] = value
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
provider sends it's subscription channel name as response to client heartbeat, we will store that in the corresponding storageclient as an annotation value.

this will help in making upgrade decisions going forward.

part of [RHSTOR-5496]