### PR TITLE
csi: enable csi-omap based on key in operator config

### DIFF
--- a/bundle/manifests/ocs-client-operator-config_v1_configmap.yaml
+++ b/bundle/manifests/ocs-client-operator-config_v1_configmap.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
+data:
+  generateRbdOMapInfo: "true"
 kind: ConfigMap
 metadata:
   name: ocs-client-operator-config

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2024-11-13T08:34:27Z"
+    createdAt: "2024-11-14T15:13:37Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,7 +9,9 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-- name: config
+- literals:
+  - generateRbdOMapInfo=true
+  name: config
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -67,6 +67,7 @@ const (
 	manageNoobaaSubKey     = "manageNoobaaSubscription"
 	subscriptionLabelKey   = "managed-by"
 	subscriptionLabelValue = "webhook.subscription.ocs.openshift.io"
+	generateRbdOMapInfoKey = "generateRbdOMapInfo"
 
 	operatorConfigMapFinalizer = "ocs-client-operator.ocs.openshift.io/storageused"
 	subPackageIndexName        = "index:subscriptionPackage"
@@ -341,6 +342,7 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI() error {
 		if err := c.own(rbdDriver); err != nil {
 			return fmt.Errorf("failed to own csi rbd driver: %v", err)
 		}
+		rbdDriver.Spec.GenerateOMapInfo = ptr.To(c.shouldGenerateRBDOmapInfo())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile rbd driver: %v", err)
@@ -505,6 +507,11 @@ func (c *OperatorConfigMapReconciler) getNoobaaSubManagementConfig() bool {
 		return false
 	}
 	return val
+}
+
+func (c *OperatorConfigMapReconciler) shouldGenerateRBDOmapInfo() bool {
+	valAsString := strings.ToLower(c.operatorConfigMap.Data[generateRbdOMapInfoKey])
+	return valAsString == strconv.FormatBool(true)
 }
 
 func (c *OperatorConfigMapReconciler) get(obj client.Object, opts ...client.GetOption) error {


### PR DESCRIPTION
The csi-omap generator needs to the enabled on the application cluster for RDR. 

Add a new key to operator configMap controller to enable omap. If the key is not set we will always enable this option on operator Config CR. If key is available we will set the value to what was provider in `ocs-client-operator-config`