### PR TITLE
Refactor CSI package code to reduce memory, GC overhead, and "order of operations" considerations

### DIFF
--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -152,7 +152,7 @@ func (c *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	err = c.createOrUpdate(c.scc, func() error {
 		// TODO: this is a hack to preserve the resourceVersion of the SCC
 		resourceVersion := c.scc.ResourceVersion
-		csi.GetSecurityContextConstraints(c.OperatorNamespace).DeepCopyInto(c.scc)
+		csi.SetSecurityContextConstraintsDesiredState(c.scc, c.OperatorNamespace)
 		c.scc.ResourceVersion = resourceVersion
 		return nil
 	})
@@ -210,10 +210,10 @@ func (c *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		},
 	}
 	err = c.createOrUpdate(c.cephFSDeployment, func() error {
-		csi.GetCephFSDeployment(c.OperatorNamespace).DeepCopyInto(c.cephFSDeployment)
 		if err := c.own(c.cephFSDeployment); err != nil {
 			return err
 		}
+		csi.SetCephFSDeploymentDesiredState(c.cephFSDeployment)
 		return nil
 	})
 	if err != nil {
@@ -223,15 +223,15 @@ func (c *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	c.cephFSDaemonSet = &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      csi.CephFSDamonSetName,
+			Name:      csi.CephFSDaemonSetName,
 			Namespace: c.OperatorNamespace,
 		},
 	}
 	err = c.createOrUpdate(c.cephFSDaemonSet, func() error {
-		csi.GetCephFSDaemonSet(c.OperatorNamespace).DeepCopyInto(c.cephFSDaemonSet)
 		if err := c.own(c.cephFSDaemonSet); err != nil {
 			return err
 		}
+		csi.SetCephFSDaemonSetDesiredState(c.cephFSDaemonSet)
 		return nil
 	})
 	if err != nil {
@@ -246,10 +246,10 @@ func (c *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		},
 	}
 	err = c.createOrUpdate(c.rbdDeployment, func() error {
-		csi.GetRBDDeployment(c.OperatorNamespace).DeepCopyInto(c.rbdDeployment)
 		if err := c.own(c.rbdDeployment); err != nil {
 			return err
 		}
+		csi.SetRBDDeploymentDesiredState(c.rbdDeployment)
 		return nil
 	})
 	if err != nil {
@@ -264,10 +264,10 @@ func (c *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		},
 	}
 	err = c.createOrUpdate(c.rbdDaemonSet, func() error {
-		csi.GetRBDDaemonSet(c.OperatorNamespace).DeepCopyInto(c.rbdDaemonSet)
 		if err := c.own(c.rbdDaemonSet); err != nil {
 			return err
 		}
+		csi.SetRBDDaemonSetDesiredState(c.rbdDaemonSet)
 		return nil
 	})
 	if err != nil {

--- a/pkg/csi/cephfsdeployment.go
+++ b/pkg/csi/cephfsdeployment.go
@@ -22,190 +22,150 @@ import (
 	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
 const (
 	CephFSDeploymentName = "csi-cephfsplugin-provisioner"
+
+	cephFSDeploymentContainerName = "csi-cephfsplugin"
 )
 
 var cephfsDeploymentLabels = map[string]string{
 	"app": "csi-cephfsplugin-provisioner",
 }
 
-func GetCephFSDeployment(namespace string) *appsv1.Deployment {
-
-	provisioner := templates.ProvisionerContainer.DeepCopy()
-	provisioner.Args = append(provisioner.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	provisioner.Image = sidecarImages.ContainerImages.ProvisionerImageURL
-
-	attacher := templates.AttacherContainer.DeepCopy()
-	attacher.Args = append(attacher.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	attacher.Image = sidecarImages.ContainerImages.AttacherImageURL
-
-	resizer := templates.ResizerContainer.DeepCopy()
-	resizer.Args = append(resizer.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	resizer.Image = sidecarImages.ContainerImages.ResizerImageURL
-
-	snapshotter := templates.SnapshotterContainer.DeepCopy()
-	snapshotter.Args = append(snapshotter.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	snapshotter.Image = sidecarImages.ContainerImages.SnapshotterImageURL
-
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      CephFSDeploymentName,
-			Namespace: namespace,
-			Labels:    cephfsDeploymentLabels,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To(int32(2)),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: cephfsDeploymentLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      CephFSDeploymentName,
-					Namespace: namespace,
-					Labels:    cephfsDeploymentLabels,
+var cephFSDeploymentSpec = appsv1.DeploymentSpec{
+	Replicas: ptr.To(int32(2)),
+	Selector: &metav1.LabelSelector{
+		MatchLabels: cephfsDeploymentLabels,
+	},
+	Template: corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			ServiceAccountName: cephFSProvisionerServiceAccountName,
+			Containers: []corev1.Container{
+				{Name: templates.ProvisionerContainer.Name},
+				{Name: templates.AttacherContainer.Name},
+				{Name: templates.ResizerContainer.Name},
+				{Name: templates.SnapshotterContainer.Name},
+				{
+					Name:            cephFSDeploymentContainerName,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Args: []string{
+						"--nodeid=$(NODE_ID)",
+						"--endpoint=$(CSI_ENDPOINT)",
+						"--v=5",
+						"--pidlimit=-1",
+						"--type=cephfs",
+						"--controllerserver=true",
+						fmt.Sprintf("--drivername=%s", GetCephFSDriverName()),
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "status.podIP",
+								},
+							},
+						},
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name:  "CSI_ENDPOINT",
+							Value: templates.DefaultProvisionerSocketPath,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "socket-dir",
+							MountPath: templates.DefaultSocketDir,
+						},
+						{
+							Name:      "host-dev",
+							MountPath: "/dev",
+						},
+						{
+							Name:      "host-sys",
+							MountPath: "/sys",
+						},
+						{
+							Name:      "lib-modules",
+							MountPath: "/lib/modules",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "ceph-csi-configs",
+							MountPath: "/etc/ceph-csi-config",
+						},
+						{
+							Name:      "keys-tmp-dir",
+							MountPath: "/tmp/csi/keys",
+						},
+					},
 				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: cephFSProvisionerServiceAccountName,
-					Containers: append([]corev1.Container{},
-						*provisioner,
-						*attacher,
-						*resizer,
-						*snapshotter,
-						v1.Container{
-							Name:            "csi-cephfsplugin",
-							Image:           sidecarImages.ContainerImages.CephCSIImageURL,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Args: []string{
-								"--nodeid=$(NODE_ID)",
-								"--endpoint=$(CSI_ENDPOINT)",
-								"--v=5",
-								"--pidlimit=-1",
-								"--type=cephfs",
-								"--controllerserver=true",
-								fmt.Sprintf("--drivername=%s", GetCephFSDriverName()),
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name: "POD_IP",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "status.podIP",
-										},
-									},
-								},
-								{
-									Name: "POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-								{
-									Name:  "CSI_ENDPOINT",
-									Value: templates.DefaultProvisionerSocketPath,
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "socket-dir",
-									MountPath: templates.DefaultSocketDir,
-								},
-								{
-									Name:      "host-dev",
-									MountPath: "/dev",
-								},
-								{
-									Name:      "host-sys",
-									MountPath: "/sys",
-								},
-								{
-									Name:      "lib-modules",
-									MountPath: "/lib/modules",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "ceph-csi-configs",
-									MountPath: "/etc/ceph-csi-config",
-								},
-								{
-									Name:      "keys-tmp-dir",
-									MountPath: "/tmp/csi/keys",
-								},
-							},
+			},
+			PriorityClassName: "system-cluster-critical",
+			Volumes: []corev1.Volume{
+				{
+					Name: "host-dev",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev",
 						},
-					),
+					},
+				},
+				{
+					Name: "host-sys",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/sys",
+						},
+					},
+				},
+				{
+					Name: "lib-modules",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/lib/modules",
+						},
+					},
+				},
+				{
+					Name: "socket-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
+						},
+					},
+				},
 
-					PriorityClassName: "system-cluster-critical",
-					Volumes: []corev1.Volume{
-						{
-							Name: "host-dev",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/dev",
-								},
-							},
+				{
+					Name: "keys-tmp-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
 						},
-						{
-							Name: "host-sys",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/sys",
-								},
+					},
+				},
+				{
+					Name: "ceph-csi-configs",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: templates.MonConfigMapName,
 							},
-						},
-						{
-							Name: "lib-modules",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/lib/modules",
-								},
-							},
-						},
-						{
-							Name: "socket-dir",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
-								},
-							},
-						},
-
-						{
-							Name: "keys-tmp-dir",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
-								},
-							},
-						},
-						{
-							Name: "ceph-csi-configs",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: templates.MonConfigMapName,
-									},
-									Items: []corev1.KeyToPath{
-										{
-											Key:  "config.json",
-											Path: "config.json",
-										},
-									},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "config.json",
+									Path: "config.json",
 								},
 							},
 						},
@@ -213,5 +173,47 @@ func GetCephFSDeployment(namespace string) *appsv1.Deployment {
 				},
 			},
 		},
+	},
+}
+
+func SetCephFSDeploymentDesiredState(deploy *appsv1.Deployment) {
+	// Copy required labels
+	for key := range cephfsDaemonsetLabels {
+		deploy.Labels[key] = cephfsDaemonsetLabels[key]
 	}
+
+	// Update the deployment set with desired spec
+	cephFSDeploymentSpec.DeepCopyInto(&deploy.Spec)
+
+	// Find and Update placeholder containers with desired state
+	leaderElectionArg := fmt.Sprintf("--leader-election-namespace=%s", deploy.Namespace)
+	for i := range deploy.Spec.Template.Spec.Containers {
+		c := &deploy.Spec.Template.Spec.Containers[i]
+
+		switch c.Name {
+		case templates.ProvisionerContainer.Name:
+			templates.ProvisionerContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.ProvisionerImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.AttacherContainer.Name:
+			templates.AttacherContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.AttacherImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.ResizerContainer.Name:
+			templates.ResizerContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.ResizerImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.SnapshotterContainer.Name:
+			templates.SnapshotterContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.SnapshotterImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case cephFSDeploymentContainerName:
+			c.Image = sidecarImages.ContainerImages.CephCSIImageURL
+		}
+	}
+
 }

--- a/pkg/csi/rbddaemonset.go
+++ b/pkg/csi/rbddaemonset.go
@@ -39,7 +39,6 @@ import (
 	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -52,349 +51,297 @@ var (
 
 const (
 	RBDDaemonSetName = "csi-rbdplugin"
+
+	rbdDaemonSetContainerName = "csi-rbdplugin"
 )
 
-func GetRBDDaemonSet(namespace string) *appsv1.DaemonSet {
-	driverRegistrar := templates.DriverRegistrar.DeepCopy()
-	driverRegistrar.Image = sidecarImages.ContainerImages.DriverRegistrarImageURL
-	driverRegistrar.Args = append(
-		driverRegistrar.Args,
-		fmt.Sprintf("--kubelet-registration-path=%s/plugins/%s/csi.sock",
-			templates.DefaultKubeletDirPath,
-			GetRBDDriverName()),
-	)
-	return &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      RBDDaemonSetName,
-			Namespace: namespace,
-			Labels:    rbdDaemonsetLabels,
-		},
-		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: rbdDaemonsetLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      RBDDaemonSetName,
-					Namespace: namespace,
-					Labels:    rbdDaemonsetLabels,
+var rbdDaemonSetSpec = appsv1.DaemonSetSpec{
+	Selector: &metav1.LabelSelector{
+		MatchLabels: rbdDaemonsetLabels,
+	},
+	Template: corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			ServiceAccountName: rbdPluginServiceAccountName,
+			HostNetwork:        true,
+			HostPID:            true,
+			PriorityClassName:  "system-node-critical",
+			Containers: []corev1.Container{
+				{Name: templates.DriverRegistrar.Name},
+				{Name: templates.CSIAddonsContainer.Name},
+				{
+					Name:            rbdDaemonSetContainerName,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:               ptr.To(true),
+						AllowPrivilegeEscalation: ptr.To(true),
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{
+								"SYS_ADMIN",
+							},
+						},
+					},
+					Args: []string{
+						"--nodeid=$(NODE_ID)",
+						"--endpoint=$(CSI_ENDPOINT)",
+						"--v=5",
+						"--pidlimit=-1",
+						"--type=rbd",
+						"--nodeserver=true",
+						fmt.Sprintf("--drivername=%s", GetRBDDriverName()),
+						fmt.Sprintf("--stagingpath=%s/plugins/kubernetes.io/csi/", templates.DefaultKubeletDirPath),
+						"--csi-addons-endpoint=$(CSIADDONS_ENDPOINT)",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "status.podIP",
+								},
+							},
+						},
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name:  "CSI_ENDPOINT",
+							Value: templates.DefaultPluginSocketPath,
+						},
+						{
+							Name: "NODE_ID",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name:  "CSIADDONS_ENDPOINT",
+							Value: "unix:///csi/csi-addons.sock",
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "plugin-dir",
+							MountPath: templates.DefaultSocketDir,
+						},
+						{
+							Name:      "host-dev",
+							MountPath: "/dev",
+						},
+						{
+							Name:      "host-sys",
+							MountPath: "/sys",
+						},
+						{
+							Name:      "lib-modules",
+							MountPath: "/lib/modules",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "ceph-csi-configs",
+							MountPath: "/etc/ceph-csi-config",
+						},
+						{
+							Name:      "keys-tmp-dir",
+							MountPath: "/tmp/csi/keys",
+						},
+						{
+							Name:      "host-run-mount",
+							MountPath: "/run/mount",
+						},
+						{
+							Name:             "csi-plugins-dir",
+							MountPath:        fmt.Sprintf("%s/plugins/", templates.DefaultKubeletDirPath),
+							MountPropagation: &biDirectionalMount,
+						},
+						{
+							Name:             "pods-mount-dir",
+							MountPath:        fmt.Sprintf("%s/pods", templates.DefaultKubeletDirPath),
+							MountPropagation: &biDirectionalMount,
+						},
+						{
+							Name:      "ceph-csi-kms-config",
+							MountPath: "/etc/ceph-csi-encryption-kms-config/",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "oidc-token",
+							MountPath: "/run/secrets/tokens",
+							ReadOnly:  true,
+						},
+					},
 				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: rbdPluginServiceAccountName,
-					HostNetwork:        true,
-					HostPID:            true,
-					PriorityClassName:  "system-node-critical",
-					Containers: append([]corev1.Container{},
-						*driverRegistrar,
-						v1.Container{
-							Name:            "csi-rbdplugin",
-							Image:           sidecarImages.ContainerImages.CephCSIImageURL,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							SecurityContext: &corev1.SecurityContext{
-								Privileged:               ptr.To(true),
-								AllowPrivilegeEscalation: ptr.To(true),
-								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{
-										"SYS_ADMIN",
-									},
-								},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "host-dev",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev",
+						},
+					},
+				},
+				{
+					Name: "host-sys",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/sys",
+						},
+					},
+				},
+				{
+					Name: "lib-modules",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/lib/modules",
+						},
+					},
+				},
+				{
+					Name: "host-run-mount",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/run/mount",
+						},
+					},
+				},
+				{
+					Name: "keys-tmp-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
+						},
+					},
+				},
+				{
+					Name: "ceph-csi-configs",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: templates.MonConfigMapName,
 							},
-							Args: []string{
-								"--nodeid=$(NODE_ID)",
-								"--endpoint=$(CSI_ENDPOINT)",
-								"--v=5",
-								"--pidlimit=-1",
-								"--type=rbd",
-								"--nodeserver=true",
-								fmt.Sprintf("--drivername=%s", GetRBDDriverName()),
-								fmt.Sprintf("--stagingpath=%s/plugins/kubernetes.io/csi/", templates.DefaultKubeletDirPath),
-								"--csi-addons-endpoint=$(CSIADDONS_ENDPOINT)",
-							},
-							Env: []corev1.EnvVar{
+							Items: []corev1.KeyToPath{
 								{
-									Name: "POD_IP",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "status.podIP",
-										},
-									},
-								},
-								{
-									Name: "POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-								{
-									Name:  "CSI_ENDPOINT",
-									Value: templates.DefaultPluginSocketPath,
-								},
-								{
-									Name: "NODE_ID",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "CSIADDONS_ENDPOINT",
-									Value: "unix:///csi/csi-addons.sock",
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "plugin-dir",
-									MountPath: templates.DefaultSocketDir,
-								},
-								{
-									Name:      "host-dev",
-									MountPath: "/dev",
-								},
-								{
-									Name:      "host-sys",
-									MountPath: "/sys",
-								},
-								{
-									Name:      "lib-modules",
-									MountPath: "/lib/modules",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "ceph-csi-configs",
-									MountPath: "/etc/ceph-csi-config",
-								},
-								{
-									Name:      "keys-tmp-dir",
-									MountPath: "/tmp/csi/keys",
-								},
-								{
-									Name:      "host-run-mount",
-									MountPath: "/run/mount",
-								},
-								{
-									Name:             "csi-plugins-dir",
-									MountPath:        fmt.Sprintf("%s/plugins/", templates.DefaultKubeletDirPath),
-									MountPropagation: &biDirectionalMount,
-								},
-								{
-									Name:             "pods-mount-dir",
-									MountPath:        fmt.Sprintf("%s/pods", templates.DefaultKubeletDirPath),
-									MountPropagation: &biDirectionalMount,
-								},
-								{
-									Name:      "ceph-csi-kms-config",
-									MountPath: "/etc/ceph-csi-encryption-kms-config/",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "oidc-token",
-									MountPath: "/run/secrets/tokens",
-									ReadOnly:  true,
+									Key:  "config.json",
+									Path: "config.json",
 								},
 							},
 						},
-						v1.Container{
-							Name:            "csi-addons",
-							Image:           sidecarImages.ContainerImages.CSIADDONSImageURL,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							SecurityContext: &corev1.SecurityContext{
-								Privileged:               ptr.To(true),
-								AllowPrivilegeEscalation: ptr.To(true),
+					},
+				},
+				{
+					Name: "plugin-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: fmt.Sprintf("%s/plugins/%s", templates.DefaultKubeletDirPath, GetRBDDriverName()),
+							Type: &hostPathDirectoryorCreate,
+						},
+					},
+				},
+				{
+					Name: "csi-plugins-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: fmt.Sprintf("%s/plugins/", templates.DefaultKubeletDirPath),
+							Type: &hostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "registration-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: fmt.Sprintf("%s/plugins_registry/", templates.DefaultKubeletDirPath),
+							Type: &hostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "pods-mount-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: fmt.Sprintf("%s/pods", templates.DefaultKubeletDirPath),
+							Type: &hostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: "ceph-csi-kms-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: templates.EncryptionConfigMapName,
 							},
-							Args: []string{
-								"--node-id=$(NODE_ID)",
-								"--v=5",
-								"--pod=$(POD_NAME)",
-								"--namespace=$(POD_NAMESPACE)",
-								"--pod-uid=$(POD_UID)",
-								fmt.Sprintf("--stagingpath=%s/plugins/kubernetes.io/csi/", templates.DefaultKubeletDirPath),
-								"--csi-addons-address=$(CSIADDONS_ENDPOINT)",
-								"--controller-port=9070",
-							},
-							Ports: []v1.ContainerPort{
+							Items: []corev1.KeyToPath{
 								{
-									ContainerPort: 9070,
+									Key:  "config.json",
+									Path: "config.json",
 								},
 							},
-							Env: []corev1.EnvVar{
+						},
+					},
+				},
+				{
+					Name: "oidc-token", VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
 								{
-									Name: "POD_UID",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.uid",
-										},
-									},
-								},
-								{
-									Name: "POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-								{
-									Name: "POD_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.name",
-										},
-									},
-								},
-								{
-									Name: "NODE_ID",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "CSIADDONS_ENDPOINT",
-									Value: "unix:///csi/csi-addons.sock",
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "plugin-dir",
-									MountPath: templates.DefaultSocketDir,
-								},
-							},
-						},
-					),
-					Volumes: []corev1.Volume{
-						{
-							Name: "host-dev",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/dev",
-								},
-							},
-						},
-						{
-							Name: "host-sys",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/sys",
-								},
-							},
-						},
-						{
-							Name: "lib-modules",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/lib/modules",
-								},
-							},
-						},
-						{
-							Name: "host-run-mount",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/run/mount",
-								},
-							},
-						},
-						{
-							Name: "keys-tmp-dir",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
-								},
-							},
-						},
-						{
-							Name: "ceph-csi-configs",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: templates.MonConfigMapName,
-									},
-									Items: []corev1.KeyToPath{
-										{
-											Key:  "config.json",
-											Path: "config.json",
-										},
-									},
-								},
-							},
-						},
-						{
-							Name: "plugin-dir",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: fmt.Sprintf("%s/plugins/%s", templates.DefaultKubeletDirPath, GetRBDDriverName()),
-									Type: &hostPathDirectoryorCreate,
-								},
-							},
-						},
-						{
-							Name: "csi-plugins-dir",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: fmt.Sprintf("%s/plugins/", templates.DefaultKubeletDirPath),
-									Type: &hostPathDirectory,
-								},
-							},
-						},
-						{
-							Name: "registration-dir",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: fmt.Sprintf("%s/plugins_registry/", templates.DefaultKubeletDirPath),
-									Type: &hostPathDirectory,
-								},
-							},
-						},
-						{
-							Name: "pods-mount-dir",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: fmt.Sprintf("%s/pods", templates.DefaultKubeletDirPath),
-									Type: &hostPathDirectory,
-								},
-							},
-						},
-						{
-							Name: "ceph-csi-kms-config",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: templates.EncryptionConfigMapName,
-									},
-									Items: []corev1.KeyToPath{
-										{
-											Key:  "config.json",
-											Path: "config.json",
-										},
-									},
-								},
-							},
-						},
-						{
-							Name: "oidc-token", VolumeSource: corev1.VolumeSource{
-								Projected: &corev1.ProjectedVolumeSource{
-									Sources: []corev1.VolumeProjection{
-										{
-											ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-												Path:              "oidc-token",
-												ExpirationSeconds: ptr.To(int64(3600)),
-												Audience:          "ceph-csi-kms",
-											},
-										},
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Path:              "oidc-token",
+										ExpirationSeconds: ptr.To(int64(3600)),
+										Audience:          "ceph-csi-kms",
 									},
 								},
 							},
 						},
 					},
-					Tolerations: []corev1.Toleration{
-						utils.GetTolerationForCSIPods(),
-					},
 				},
 			},
+			Tolerations: []corev1.Toleration{
+				utils.GetTolerationForCSIPods(),
+			},
 		},
+	},
+}
+
+func SetRBDDaemonSetDesiredState(ds *appsv1.DaemonSet) {
+	// Copy required labels
+	for key := range rbdDaemonsetLabels {
+		ds.Labels[key] = cephfsDaemonsetLabels[key]
+	}
+
+	// Update the demaon set with desired state
+	rbdDaemonSetSpec.DeepCopyInto(&ds.Spec)
+
+	// Update containers spec with desired state
+	for i := range ds.Spec.Template.Spec.Containers {
+		c := &ds.Spec.Template.Spec.Containers[i]
+		switch c.Name {
+		case templates.DriverRegistrar.Name:
+			templates.DriverRegistrar.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.DriverRegistrarImageURL
+			c.Args = append(c.Args, fmt.Sprintf(
+				"--kubelet-registration-path=%s/plugins/%s/csi.sock",
+				templates.DefaultKubeletDirPath,
+				GetRBDDriverName(),
+			))
+
+		case templates.CSIAddonsContainer.Name:
+			templates.CSIAddonsContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.CSIADDONSImageURL
+			vol := utils.Find(c.VolumeMounts, func(vol *corev1.VolumeMount) bool {
+				return vol.Name == "socket-dir"
+			})
+			vol.Name = "plugin-dir"
+
+		case rbdDaemonSetContainerName:
+			c.Image = sidecarImages.ContainerImages.CephCSIImageURL
+		}
 	}
 }

--- a/pkg/csi/rbddeployment.go
+++ b/pkg/csi/rbddeployment.go
@@ -22,7 +22,6 @@ import (
 	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -33,222 +32,177 @@ var rbdDeploymentLabels = map[string]string{
 
 const (
 	RBDDeploymentName = "csi-rbdplugin-provisioner"
+
+	rbdDeploymentContainerName = "csi-rbdplugin"
 )
 
-func GetRBDDeployment(namespace string) *appsv1.Deployment {
-	provisioner := templates.ProvisionerContainer.DeepCopy()
-	provisioner.Args = append(provisioner.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	provisioner.Image = sidecarImages.ContainerImages.ProvisionerImageURL
-
-	attacher := templates.AttacherContainer.DeepCopy()
-	attacher.Args = append(attacher.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	attacher.Image = sidecarImages.ContainerImages.AttacherImageURL
-
-	resizer := templates.ResizerContainer.DeepCopy()
-	resizer.Args = append(resizer.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	resizer.Image = sidecarImages.ContainerImages.ResizerImageURL
-
-	snapshotter := templates.SnapshotterContainer.DeepCopy()
-	snapshotter.Args = append(snapshotter.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	snapshotter.Image = sidecarImages.ContainerImages.SnapshotterImageURL
-
-	csiAddons := templates.CSIAddonsContainer.DeepCopy()
-	csiAddons.Args = append(csiAddons.Args,
-		fmt.Sprintf("--leader-election-namespace=%s", namespace),
-	)
-	csiAddons.Image = sidecarImages.ContainerImages.CSIADDONSImageURL
-
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      RBDDeploymentName,
-			Namespace: namespace,
-			Labels:    rbdDeploymentLabels,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To(int32(2)),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: rbdDeploymentLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      RBDDeploymentName,
-					Namespace: namespace,
-					Labels:    rbdDeploymentLabels,
+var rbdDeploymentSpec = appsv1.DeploymentSpec{
+	Replicas: ptr.To(int32(2)),
+	Selector: &metav1.LabelSelector{
+		MatchLabels: rbdDeploymentLabels,
+	},
+	Template: corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			ServiceAccountName: rbdProvisionerServiceAccountName,
+			Containers: []corev1.Container{
+				{Name: templates.ProvisionerContainer.Name},
+				{Name: templates.AttacherContainer.Name},
+				{Name: templates.ResizerContainer.Name},
+				{Name: templates.SnapshotterContainer.Name},
+				{Name: templates.CSIAddonsContainer.Name},
+				{
+					Name:            rbdDeploymentContainerName,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Args: []string{
+						"--nodeid=$(NODE_ID)",
+						"--endpoint=$(CSI_ENDPOINT)",
+						"--v=5",
+						"--pidlimit=-1",
+						"--type=rbd",
+						"--controllerserver=true",
+						fmt.Sprintf("--csi-addons-endpoint=%s", templates.DefaultCSIAddonsSocketPath),
+						fmt.Sprintf("--drivername=%s", GetRBDDriverName()),
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "status.podIP",
+								},
+							},
+						},
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name:  "CSI_ENDPOINT",
+							Value: templates.DefaultProvisionerSocketPath,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "socket-dir",
+							MountPath: templates.DefaultSocketDir,
+						},
+						{
+							Name:      "host-dev",
+							MountPath: "/dev",
+						},
+						{
+							Name:      "host-sys",
+							MountPath: "/sys",
+						},
+						{
+							Name:      "lib-modules",
+							MountPath: "/lib/modules",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "ceph-csi-configs",
+							MountPath: "/etc/ceph-csi-config",
+						},
+						{
+							Name:      "keys-tmp-dir",
+							MountPath: "/tmp/csi/keys",
+						},
+						{
+							Name:      "ceph-csi-kms-config",
+							MountPath: "/etc/ceph-csi-encryption-kms-config/",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "oidc-token",
+							MountPath: "/run/secrets/tokens",
+							ReadOnly:  true,
+						},
+					},
 				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: rbdProvisionerServiceAccountName,
-					Containers: append([]corev1.Container{},
-						*provisioner,
-						*attacher,
-						*resizer,
-						*snapshotter,
-						*csiAddons,
-						v1.Container{
-							Name:            "csi-rbdplugin",
-							Image:           sidecarImages.ContainerImages.CephCSIImageURL,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Args: []string{
-								"--nodeid=$(NODE_ID)",
-								"--endpoint=$(CSI_ENDPOINT)",
-								"--v=5",
-								"--pidlimit=-1",
-								"--type=rbd",
-								"--controllerserver=true",
-								fmt.Sprintf("--csi-addons-endpoint=%s", templates.DefaultCSIAddonsSocketPath),
-								fmt.Sprintf("--drivername=%s", GetRBDDriverName()),
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name: "POD_IP",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "status.podIP",
-										},
-									},
-								},
-								{
-									Name: "POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-								{
-									Name:  "CSI_ENDPOINT",
-									Value: templates.DefaultProvisionerSocketPath,
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "socket-dir",
-									MountPath: templates.DefaultSocketDir,
-								},
-								{
-									Name:      "host-dev",
-									MountPath: "/dev",
-								},
-								{
-									Name:      "host-sys",
-									MountPath: "/sys",
-								},
-								{
-									Name:      "lib-modules",
-									MountPath: "/lib/modules",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "ceph-csi-configs",
-									MountPath: "/etc/ceph-csi-config",
-								},
-								{
-									Name:      "keys-tmp-dir",
-									MountPath: "/tmp/csi/keys",
-								},
-								{
-									Name:      "ceph-csi-kms-config",
-									MountPath: "/etc/ceph-csi-encryption-kms-config/",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "oidc-token",
-									MountPath: "/run/secrets/tokens",
-									ReadOnly:  true,
-								},
-							},
+			},
+			PriorityClassName: "system-cluster-critical",
+			Volumes: []corev1.Volume{
+				{
+					Name: "host-dev",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev",
 						},
-					),
+					},
+				},
+				{
+					Name: "host-sys",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/sys",
+						},
+					},
+				},
+				{
+					Name: "lib-modules",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/lib/modules",
+						},
+					},
+				},
+				{
+					Name: "socket-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
+						},
+					},
+				},
 
-					PriorityClassName: "system-cluster-critical",
-					Volumes: []corev1.Volume{
-						{
-							Name: "host-dev",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/dev",
+				{
+					Name: "keys-tmp-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
+						},
+					},
+				},
+				{
+					Name: "ceph-csi-configs",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: templates.MonConfigMapName,
+							},
+						},
+					},
+				},
+				{
+					Name: "ceph-csi-kms-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: templates.EncryptionConfigMapName,
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "config.json",
+									Path: "config.json",
 								},
 							},
 						},
-						{
-							Name: "host-sys",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/sys",
-								},
-							},
-						},
-						{
-							Name: "lib-modules",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/lib/modules",
-								},
-							},
-						},
-						{
-							Name: "socket-dir",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
-								},
-							},
-						},
-
-						{
-							Name: "keys-tmp-dir",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
-								},
-							},
-						},
-						{
-							Name: "ceph-csi-configs",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: templates.MonConfigMapName,
-									},
-								},
-							},
-						},
-						{
-							Name: "ceph-csi-kms-config",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: templates.EncryptionConfigMapName,
-									},
-									Items: []corev1.KeyToPath{
-										{
-											Key:  "config.json",
-											Path: "config.json",
-										},
-									},
-								},
-							},
-						},
-
-						{
-							Name: "oidc-token",
-							VolumeSource: corev1.VolumeSource{
-								Projected: &corev1.ProjectedVolumeSource{
-									Sources: []corev1.VolumeProjection{
-										{
-											ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-												Path:              "oidc-token",
-												ExpirationSeconds: ptr.To(int64(3600)),
-												Audience:          "ceph-csi-kms",
-											},
-										},
+					},
+				},
+				{
+					Name: "oidc-token",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Path:              "oidc-token",
+										ExpirationSeconds: ptr.To(int64(3600)),
+										Audience:          "ceph-csi-kms",
 									},
 								},
 							},
@@ -257,5 +211,52 @@ func GetRBDDeployment(namespace string) *appsv1.Deployment {
 				},
 			},
 		},
+	},
+}
+
+func SetRBDDeploymentDesiredState(deploy *appsv1.Deployment) {
+	// Copy required labels
+	for key := range rbdDaemonsetLabels {
+		deploy.Labels[key] = cephfsDaemonsetLabels[key]
+	}
+
+	// Update the deployment set with desired spec
+	rbdDeploymentSpec.DeepCopyInto(&deploy.Spec)
+
+	// Find and Update placeholder containers with desired state
+	leaderElectionArg := fmt.Sprintf("--leader-election-namespace=%s", deploy.Namespace)
+
+	for i := range deploy.Spec.Template.Spec.Containers {
+		c := &deploy.Spec.Template.Spec.Containers[i]
+
+		switch c.Name {
+		case templates.ProvisionerContainer.Name:
+			templates.ProvisionerContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.ProvisionerImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.AttacherContainer.Name:
+			templates.AttacherContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.AttacherImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.ResizerContainer.Name:
+			templates.ResizerContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.ResizerImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.SnapshotterContainer.Name:
+			templates.SnapshotterContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.SnapshotterImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case templates.CSIAddonsContainer.Name:
+			templates.CSIAddonsContainer.DeepCopyInto(c)
+			c.Image = sidecarImages.ContainerImages.CSIADDONSImageURL
+			c.Args = append(c.Args, leaderElectionArg)
+
+		case rbdDeploymentContainerName:
+			c.Image = sidecarImages.ContainerImages.CephCSIImageURL
+		}
 	}
 }

--- a/pkg/csi/scc.go
+++ b/pkg/csi/scc.go
@@ -21,7 +21,6 @@ import (
 
 	secv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -36,50 +35,54 @@ var (
 	rbdPluginServiceAccountName         = "ocs-client-operator-csi-rbd-plugin-sa"
 )
 
-func GetSecurityContextConstraints(namespace string) *secv1.SecurityContextConstraints {
-	return &secv1.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: SCCName,
-		},
-		// CSI daemonset pod needs to run as privileged
-		AllowPrivilegedContainer: true,
-		// CSI daemonset pod needs hostnetworking
-		AllowHostNetwork: true,
-		// This need to be set to true as we use HostPath
-		AllowHostDirVolumePlugin: true,
-		// Required for csi addons
-		AllowHostPorts: true,
-		// Needed as we are setting this in RBD plugin pod
-		AllowHostPID: true,
-		// Required for multus and encryption
-		AllowHostIPC: true,
-		// SYS_ADMIN is needed for rbd to execute rbd map command
-		AllowedCapabilities: []corev1.Capability{"SYS_ADMIN"},
-		// # Set to false as we write to RootFilesystem inside csi containers
-		ReadOnlyRootFilesystem: false,
-		RunAsUser: secv1.RunAsUserStrategyOptions{
-			Type: secv1.RunAsUserStrategyRunAsAny,
-		},
-		SELinuxContext: secv1.SELinuxContextStrategyOptions{
-			Type: secv1.SELinuxStrategyRunAsAny,
-		},
-		FSGroup: secv1.FSGroupStrategyOptions{
-			Type: secv1.FSGroupStrategyRunAsAny,
-		},
-		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
-			Type: secv1.SupplementalGroupsStrategyRunAsAny,
-		},
-		Volumes: []secv1.FSType{
-			secv1.FSTypeHostPath,
-			secv1.FSTypeConfigMap,
-			secv1.FSTypeEmptyDir,
-			secv1.FSProjected,
-		},
-		Users: []string{
-			fmt.Sprintf("system:serviceaccount:%s:%s", namespace, cephFSProvisionerServiceAccountName),
-			fmt.Sprintf("system:serviceaccount:%s:%s", namespace, cephFSPluginServiceAccountName),
-			fmt.Sprintf("system:serviceaccount:%s:%s", namespace, rbdProvisionerServiceAccountName),
-			fmt.Sprintf("system:serviceaccount:%s:%s", namespace, rbdPluginServiceAccountName),
-		},
+var securityContext = secv1.SecurityContextConstraints{
+	// CSI daemonset pod needs to run as privileged
+	AllowPrivilegedContainer: true,
+	// CSI daemonset pod needs hostnetworking
+	AllowHostNetwork: true,
+	// This need to be set to true as we use HostPath
+	AllowHostDirVolumePlugin: true,
+	// Required for csi addons
+	AllowHostPorts: true,
+	// Needed as we are setting this in RBD plugin pod
+	AllowHostPID: true,
+	// Required for multus and encryption
+	AllowHostIPC: true,
+	// SYS_ADMIN is needed for rbd to execute rbd map command
+	AllowedCapabilities: []corev1.Capability{"SYS_ADMIN"},
+	// # Set to false as we write to RootFilesystem inside csi containers
+	ReadOnlyRootFilesystem: false,
+	RunAsUser: secv1.RunAsUserStrategyOptions{
+		Type: secv1.RunAsUserStrategyRunAsAny,
+	},
+	SELinuxContext: secv1.SELinuxContextStrategyOptions{
+		Type: secv1.SELinuxStrategyRunAsAny,
+	},
+	FSGroup: secv1.FSGroupStrategyOptions{
+		Type: secv1.FSGroupStrategyRunAsAny,
+	},
+	SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
+		Type: secv1.SupplementalGroupsStrategyRunAsAny,
+	},
+	Volumes: []secv1.FSType{
+		secv1.FSTypeHostPath,
+		secv1.FSTypeConfigMap,
+		secv1.FSTypeEmptyDir,
+		secv1.FSProjected,
+	},
+}
+
+func SetSecurityContextConstraintsDesiredState(scc *secv1.SecurityContextConstraints, ns string) {
+	// Make sure metadata is preserved
+	metadata := scc.ObjectMeta
+	securityContext.DeepCopyInto(scc)
+	scc.ObjectMeta = metadata
+
+	// Adding users based on namespace
+	scc.Users = []string{
+		fmt.Sprintf("system:serviceaccount:%s:%s", ns, cephFSProvisionerServiceAccountName),
+		fmt.Sprintf("system:serviceaccount:%s:%s", ns, cephFSPluginServiceAccountName),
+		fmt.Sprintf("system:serviceaccount:%s:%s", ns, rbdProvisionerServiceAccountName),
+		fmt.Sprintf("system:serviceaccount:%s:%s", ns, rbdPluginServiceAccountName),
 	}
 }

--- a/pkg/templates/csidriver.go
+++ b/pkg/templates/csidriver.go
@@ -25,7 +25,7 @@ var (
 	fileFSGroupPolicy = v1k8scsi.FileFSGroupPolicy
 )
 
-var CephFSCSIDriver = &v1k8scsi.CSIDriver{
+var CephFSCSIDriver = v1k8scsi.CSIDriver{
 	Spec: v1k8scsi.CSIDriverSpec{
 		AttachRequired: ptr.To(true),
 		PodInfoOnMount: ptr.To(false),
@@ -33,7 +33,7 @@ var CephFSCSIDriver = &v1k8scsi.CSIDriver{
 	},
 }
 
-var RbdCSIDriver = &v1k8scsi.CSIDriver{
+var RbdCSIDriver = v1k8scsi.CSIDriver{
 	Spec: v1k8scsi.CSIDriverSpec{
 		AttachRequired: ptr.To(true),
 		PodInfoOnMount: ptr.To(false),

--- a/pkg/templates/csisidecars.go
+++ b/pkg/templates/csisidecars.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var ProvisionerContainer = &corev1.Container{
+var ProvisionerContainer = corev1.Container{
 	Name:            "csi-provisioner",
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	Args: []string{
@@ -44,7 +44,7 @@ var ProvisionerContainer = &corev1.Container{
 	},
 }
 
-var ResizerContainer = &corev1.Container{
+var ResizerContainer = corev1.Container{
 	Name:            "csi-resizer",
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	Args: []string{
@@ -63,7 +63,7 @@ var ResizerContainer = &corev1.Container{
 	},
 }
 
-var AttacherContainer = &corev1.Container{
+var AttacherContainer = corev1.Container{
 	Name:            "csi-attacher",
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	Args: []string{
@@ -82,7 +82,7 @@ var AttacherContainer = &corev1.Container{
 	},
 }
 
-var SnapshotterContainer = &corev1.Container{
+var SnapshotterContainer = corev1.Container{
 	Name:            "csi-snapshotter",
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	Args: []string{
@@ -101,7 +101,7 @@ var SnapshotterContainer = &corev1.Container{
 	},
 }
 
-var CSIAddonsContainer = &corev1.Container{
+var CSIAddonsContainer = corev1.Container{
 	Name: "csi-addons",
 	Args: []string{
 		"--node-id=$(NODE_ID)",
@@ -162,7 +162,7 @@ var CSIAddonsContainer = &corev1.Container{
 	ImagePullPolicy: corev1.PullIfNotPresent,
 }
 
-var DriverRegistrar = &corev1.Container{
+var DriverRegistrar = corev1.Container{
 	Name:            "csi-driver-registrar",
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
The existing code is very wasteful regarding memory management of large in-memory structures. On each reconcile cycle multiple big nested structures are either fully or partially copied multiple times and in multiple locations in the codebase. This creates unnecessary pressure on the garbage collector and wastes multiple CPU cycles moving around the same bits

A second side effect of the current code structure is the creation of a fresh nested set of objects on every reconcile cycle that overwrites any metadata on existing objects. This results in a contributor’s need to be very careful and consider the order of operations when writing reconciliation functions for CSI resources. As an example, I can give the fact that the current code contains a bug where all of the owner references on CSI reconciled objects are overwritten by a deep copy operation

This PR addresses the 2 points above and reduces the number of allocations and garbage collection of in-memory reconciled objects and the need to micro-manage the order of operation on CSI objects` reconciliation.

P.S
The bug mentioned above is now solved on the main branch by the contributor changing the order op operations, but that makes this point even more valid