### PR TITLE
controllers: deploy csi correctly by adding labels

### DIFF
--- a/pkg/csi/cephfsdaemonset.go
+++ b/pkg/csi/cephfsdaemonset.go
@@ -48,6 +48,9 @@ var cephFSDaemonSetSpec = appsv1.DaemonSetSpec{
 		MatchLabels: cephfsDaemonsetLabels,
 	},
 	Template: corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: cephfsDaemonsetLabels,
+		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: cephFSPluginServiceAccountName,
 			HostNetwork:        true,
@@ -251,9 +254,7 @@ var cephFSDaemonSetSpec = appsv1.DaemonSetSpec{
 
 func SetCephFSDaemonSetDesiredState(ds *appsv1.DaemonSet) {
 	// Copy required labels
-	for key := range cephfsDaemonsetLabels {
-		ds.Labels[key] = cephfsDaemonsetLabels[key]
-	}
+	utils.AddLabels(ds, cephfsDaemonsetLabels)
 
 	// Update the demaon set with desired spec
 	cephFSDaemonSetSpec.DeepCopyInto(&ds.Spec)

--- a/pkg/csi/cephfsdeployment.go
+++ b/pkg/csi/cephfsdeployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
+	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +43,9 @@ var cephFSDeploymentSpec = appsv1.DeploymentSpec{
 		MatchLabels: cephfsDeploymentLabels,
 	},
 	Template: corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: cephfsDeploymentLabels,
+		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: cephFSProvisionerServiceAccountName,
 			Containers: []corev1.Container{
@@ -178,9 +182,7 @@ var cephFSDeploymentSpec = appsv1.DeploymentSpec{
 
 func SetCephFSDeploymentDesiredState(deploy *appsv1.Deployment) {
 	// Copy required labels
-	for key := range cephfsDaemonsetLabels {
-		deploy.Labels[key] = cephfsDaemonsetLabels[key]
-	}
+	utils.AddLabels(deploy, cephfsDeploymentLabels)
 
 	// Update the deployment set with desired spec
 	cephFSDeploymentSpec.DeepCopyInto(&deploy.Spec)

--- a/pkg/csi/rbddaemonset.go
+++ b/pkg/csi/rbddaemonset.go
@@ -60,6 +60,9 @@ var rbdDaemonSetSpec = appsv1.DaemonSetSpec{
 		MatchLabels: rbdDaemonsetLabels,
 	},
 	Template: corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: rbdDaemonsetLabels,
+		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: rbdPluginServiceAccountName,
 			HostNetwork:        true,
@@ -312,9 +315,7 @@ var rbdDaemonSetSpec = appsv1.DaemonSetSpec{
 
 func SetRBDDaemonSetDesiredState(ds *appsv1.DaemonSet) {
 	// Copy required labels
-	for key := range rbdDaemonsetLabels {
-		ds.Labels[key] = cephfsDaemonsetLabels[key]
-	}
+	utils.AddLabels(ds, rbdDaemonsetLabels)
 
 	// Update the demaon set with desired state
 	rbdDaemonSetSpec.DeepCopyInto(&ds.Spec)

--- a/pkg/csi/rbddeployment.go
+++ b/pkg/csi/rbddeployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
+	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +43,9 @@ var rbdDeploymentSpec = appsv1.DeploymentSpec{
 		MatchLabels: rbdDeploymentLabels,
 	},
 	Template: corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: rbdDeploymentLabels,
+		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: rbdProvisionerServiceAccountName,
 			Containers: []corev1.Container{
@@ -216,9 +220,7 @@ var rbdDeploymentSpec = appsv1.DeploymentSpec{
 
 func SetRBDDeploymentDesiredState(deploy *appsv1.Deployment) {
 	// Copy required labels
-	for key := range rbdDaemonsetLabels {
-		deploy.Labels[key] = cephfsDaemonsetLabels[key]
-	}
+	utils.AddLabels(deploy, rbdDeploymentLabels)
 
 	// Update the deployment set with desired spec
 	rbdDeploymentSpec.DeepCopyInto(&deploy.Spec)

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -18,7 +18,10 @@ package utils
 
 import (
 	"fmt"
+	"maps"
 	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // OperatorNamespaceEnvVar is the constant for env variable OPERATOR_NAMESPACE
@@ -59,4 +62,14 @@ func ValidateStausReporterImage() error {
 	}
 
 	return nil
+}
+
+// AddLabels adds values from newLabels to the keys on the supplied obj or overwrites values for existing keys on the obj
+func AddLabels(obj metav1.Object, newLabels map[string]string) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+		obj.SetLabels(labels)
+	}
+	maps.Copy(labels, newLabels)
 }


### PR DESCRIPTION
- fix the labels on deployment & daemonset resources
- add object meta to pod template spec for correct deployment
- create labels map if doesn't exist avoiding panic

there's a li'l pesky bug unrelated to current changeset as in the func createorupdate always updating the deployment & daemonset resources.

can be seen in the GH comments marked testing.