### PR TITLE
Fix placeholder kube-rbac-proxy image to respect supplied image during build time

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: kube-rbac-proxy:latest
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
In Kustomization we are trying to replace a image w/ name `kube-rbac-proxy` during build time, however rather than the placeholder the deployment has original image name & tag which makes update of rbac proxy image not possible via Makefile.

In d/s an hack is employed to directly change the value in resulting csv manifests and this PR fixes that providing a way to respect values set via Makefile.