### PR TITLE
update bundle w/ bumping version

### DIFF
--- a/bundle/manifests/ocs-client-operator-config_v1_configmap.yaml
+++ b/bundle/manifests/ocs-client-operator-config_v1_configmap.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocs-client-operator-config

--- a/bundle/manifests/ocs-client-operator-webhook-server_v1_service.yaml
+++ b/bundle/manifests/ocs-client-operator-webhook-server_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-cert-secret
+  creationTimestamp: null
+  name: ocs-client-operator-webhook-server
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 7443
+  selector:
+    app: ocs-client-operator
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -8,12 +8,17 @@ metadata:
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: ocs-client-operator.v4.12.0
+  name: ocs-client-operator.v4.16.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: StorageClaim is the Schema for the storageclaims API
+      displayName: Storage Claim
+      kind: StorageClaim
+      name: storageclaims.ocs.openshift.io
+      version: v1alpha1
     - description: StorageClassClaim is the Schema for the storageclassclaims API
       displayName: Storage Class Claim
       kind: StorageClassClaim
@@ -47,6 +52,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
           - secrets
           verbs:
           - create
@@ -66,6 +77,24 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - apps
@@ -119,27 +148,9 @@ spec:
           resources:
           - clusterversions
           verbs:
-          - create
-          - delete
           - get
           - list
-          - patch
-          - update
           - watch
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - clusterversions/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - clusterversions/status
-          verbs:
-          - get
-          - patch
-          - update
         - apiGroups:
           - console.openshift.io
           resources:
@@ -164,6 +175,32 @@ spec:
           - list
           - update
           - watch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclaims/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclaims/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - ocs.openshift.io
           resources:
@@ -225,6 +262,15 @@ spec:
           - list
           - watch
         - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints
@@ -242,6 +288,14 @@ spec:
           verbs:
           - create
           - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotcontents
+          verbs:
           - get
           - list
           - watch
@@ -598,6 +652,7 @@ spec:
           verbs:
           - get
           - list
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -679,12 +734,14 @@ spec:
               - emptyDir: {}
                 name: ocs-client-operator-console-nginx-tmp
       - label:
+          app: ocs-client-operator
           control-plane: controller-manager
         name: ocs-client-operator-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
+              app: ocs-client-operator
               control-plane: controller-manager
           strategy: {}
           template:
@@ -692,6 +749,7 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app: ocs-client-operator
                 control-plane: controller-manager
             spec:
               containers:
@@ -700,7 +758,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -757,6 +815,8 @@ spec:
                 volumeMounts:
                 - mountPath: /opt/config
                   name: csi-images
+                - mountPath: /etc/tls/private
+                  name: webhook-cert-secret
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: ocs-client-operator-controller-manager
@@ -765,6 +825,9 @@ spec:
               - configMap:
                   name: ocs-client-operator-csi-images
                 name: csi-images
+              - name: webhook-cert-secret
+                secret:
+                  secretName: webhook-cert-secret
       - label:
           app.kubernetes.io/name: ocs-client-operator-console
         name: console
@@ -934,4 +997,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.12.0
+  version: 4.16.0

--- a/bundle/manifests/ocs.openshift.io_storageclaims.yaml
+++ b/bundle/manifests/ocs.openshift.io_storageclaims.yaml
@@ -4,14 +4,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
-  name: storageclassclaims.ocs.openshift.io
+  name: storageclaims.ocs.openshift.io
 spec:
   group: ocs.openshift.io
   names:
-    kind: StorageClassClaim
-    listKind: StorageClassClaimList
-    plural: storageclassclaims
-    singular: storageclassclaim
+    kind: StorageClaim
+    listKind: StorageClaimList
+    plural: storageclaims
+    singular: storageclaim
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -30,13 +30,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    deprecated: true
-    deprecationWarning: StorageClassClaim API is deprecated and will be removed in
-      future version, please use StorageClaim API instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: StorageClassClaim is the Schema for the storageclassclaims API
+        description: StorageClaim is the Schema for the storageclaims API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -51,7 +48,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: StorageClassClaimSpec defines the desired state of StorageClassClaim
+            description: StorageClaimSpec defines the desired state of StorageClaim
             properties:
               encryptionMethod:
                 type: string
@@ -69,8 +66,8 @@ spec:
                 type: string
               type:
                 enum:
-                - blockpool
-                - sharedfilesystem
+                - block
+                - sharedfile
                 type: string
             required:
             - storageClient
@@ -80,17 +77,11 @@ spec:
             - message: spec is immutable
               rule: oldSelf == self
           status:
-            description: StorageClassClaimStatus defines the observed state of StorageClassClaim
+            description: StorageClaimStatus defines the observed state of StorageClaim
             properties:
               phase:
                 type: string
-              secretNames:
-                items:
-                  type: string
-                type: array
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -109,27 +115,9 @@ rules:
   resources:
   - clusterversions
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusterversions/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusterversions/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - console.openshift.io
   resources:

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.12.0
+VERSION ?= 4.16.0
 
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")


### PR DESCRIPTION
the generated bundle is out of sync w/ the config & manifests, even though they can be rebuilt we can have the bundle fully removed or keep it upto date from time to time, this PR does the latter.

for some of the controllers kubebuilder tags were added but it wasn't updated in the config and so syncing everything once.