### PR TITLE
controllers: define claimType before getting storageclass

### DIFF
--- a/controllers/storageclaim_controller.go
+++ b/controllers/storageclaim_controller.go
@@ -246,9 +246,8 @@ func (r *StorageClaimReconciler) reconcilePhases() (reconcile.Result, error) {
 				Name: r.storageClaim.Name,
 			},
 		}
-		var claimType string
+		claimType := strings.ToLower(r.storageClaim.Spec.Type)
 		if err = r.get(existing); err == nil {
-			claimType = strings.ToLower(r.storageClaim.Spec.Type)
 			sccEncryptionMethod := r.storageClaim.Spec.EncryptionMethod
 			_, scIsFSType := existing.Parameters["fsName"]
 			scEncryptionMethod, scHasEncryptionMethod := existing.Parameters["encryptionMethod"]


### PR DESCRIPTION
during first reconcile of storageclaim, storageclass will not exist and so `claimType` will have zero value which is being set inside a conditional and fails type check in switch statement as this var was reused.