### PR TITLE
Setting basedomain as cluster name

### DIFF
--- a/config/rbac/status-reporter-clusterrole.yaml
+++ b/config/rbac/status-reporter-clusterrole.yaml
@@ -22,19 +22,10 @@ rules:
       - list
       - update
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    resourceNames:
-      - cluster-config-v1
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - config.openshift.io
     resources:
       - clusterversions
+      - dns
     verbs:
       - get
       - list
-      - watch


### PR DESCRIPTION
On hosted cluster value of 
`k get cm cluster-config-v1 -nkube-system -ojsonpath='{.data.install\-config}' | yq -r .metadata.name` is empty.  
Hence, It has been decided to display the base domain regardless of whether it's an HCP or OCP cluster.