### PR TITLE
action: update docker-push action for pushing images on demand

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -7,8 +7,8 @@ on:
         required: true
         default: ocs-dev
       IMAGE_TAG:
-        required: true
-        default: latest
+        required: false
+        default: ""
 
 jobs:
   docker-push:
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - uses: actions/setup-go@v5
       with:
@@ -34,7 +32,10 @@ jobs:
       env:
         REGISTRY_NAMESPACE: ${{ github.event.inputs.REGISTRY_NAMESPACE }}
         IMAGE_TAG: ${{ github.event.inputs.IMAGE_TAG }}
+        IMAGE_TAG_SHA: ${{ github.ref_name }}-${{ github.sha }}
       run: |
-        make docker-build docker-push
+        # Set IMAGE_TAG to a calculated <branch>-<sha> if not specified
+        export IMAGE_TAG=${IMAGE_TAG:-${IMAGE_TAG_SHA:0:-33}}
+        make container-build container-push
         make bundle-build bundle-push
         make catalog-build catalog-push


### PR DESCRIPTION
relates to red-hat-storage/ocs-operator#2616, when ocs or odf operator is deployed by u/s CI they try to pull a preconfigured bundle of ocs-client-operator for deployment however that bundle is being created on demand manually.

Having a working gh-action for performing that op reduces manual work, at the same time trying to keep the action as short as possible we should set the vars correctly that corresponds to a particular release in Makefile.

Below is an example on how it was done manually
```
export VERSION=4.16.0
export IMG=quay.io/ocs-dev/ocs-client-operator:v${VERSION}
export OCS_CLIENT_CONSOLE_IMG=\
quay.io/ocs-dev/ocs-client-console:v4.15.0
export BUNDLE_IMG=quay.io/ocs-dev/ocs-client-operator-bundle:v${VERSION}
```

Apart from above, client-op depends on csi-addons and for u/s, again we are creating & pushing a bundle for that operator and use the relavent image tags of csi-addons, which will still be manual op atm.