### PR TITLE
bundle: update missing and incorrect rbac resources

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2024-05-29T07:47:01Z"
+    createdAt: "2024-05-30T10:17:44Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -640,7 +640,7 @@ spec:
         - apiGroups:
           - ""
           resourceNames:
-          - rook-ceph-mon-endpoints
+          - ceph-csi-configs
           resources:
           - configmaps
           verbs:
@@ -651,7 +651,7 @@ spec:
           - config.openshift.io
           resources:
           - clusterversions
-          - dns
+          - dnses
           verbs:
           - get
           - list

--- a/config/rbac/status-reporter-clusterrole.yaml
+++ b/config/rbac/status-reporter-clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - rook-ceph-mon-endpoints
+      - ceph-csi-configs
     verbs:
       - get
       - list
@@ -25,7 +25,7 @@ rules:
       - config.openshift.io
     resources:
       - clusterversions
-      - dns
+      - dnses
     verbs:
       - get
       - list


### PR DESCRIPTION
api resource name always is plural but we had incorrect rbac as `dns` and it should be `dnses`. For other change, `rook-ceph-mon-endpoints` is a name at provider end and in client cluster it is stored as `ceph-csi-configs`.

The regression was introduced when we restricted the rbac to specific resources at cluster role.