### PR TITLE
add annotation to csv to make storageclaim internal

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,13 +7,14 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2024-05-30T10:17:44Z"
+    createdAt: "2024-06-11T05:34:18Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
     olm.skipRange: ""
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    operators.operatorframework.io/internal-objects: '["storageclaims.ocs.openshift.io"]'
     operators.operatorframework.io/operator-type: standalone
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/red-hat-storage/ocs-client-operator

--- a/config/manifests/bases/ocs-client-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ocs-client-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
     operatorframework.io/suggested-namespace: openshift-storage
+    operators.operatorframework.io/internal-objects: '["storageclaims.ocs.openshift.io"]'
     operators.operatorframework.io/operator-type: standalone
     repository: https://github.com/red-hat-storage/ocs-client-operator
     support: Red Hat


### PR DESCRIPTION
add the annotation operators.operatorframework.io/internal-objects to the operator csv to make storageClaim internal/ to remove it from the console

Ref: https://docs.openshift.com/container-platform/4.15/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs