### PR TITLE
BUG 2276565: controllers: fixed typo subscription to subscriptions

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -225,6 +225,15 @@ spec:
           - list
           - watch
         - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - security.openshift.io
           resources:
           - securitycontextconstraints

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -198,6 +198,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints
@@ -240,14 +249,5 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - get
-  - list
   - update
   - watch

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -143,7 +143,7 @@ func (c *ClusterVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=*
-//+kubebuilder:rbac:groups=operators.coreos.com,resources=subscription,verbs=watch;get;list;update
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=watch;get;list;update
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile


### PR DESCRIPTION
rbac generation was affected because of this typo
The bug was introduced in this [PR](https://github.com/red-hat-storage/ocs-client-operator/pull/152)