### PR TITLE
RHSTOR-5883: Annotate RBD storageclasses for EncryptionKeyRotation

### DIFF
--- a/internal/controller/storageclaim_controller.go
+++ b/internal/controller/storageclaim_controller.go
@@ -51,6 +51,7 @@ import (
 const (
 	storageClaimFinalizer  = "storageclaim.ocs.openshift.io"
 	storageClaimAnnotation = "ocs.openshift.io/storageclaim"
+	keyRotationAnnotation  = "keyrotation.csiaddons.openshift.io/schedule"
 
 	pvClusterIDIndexName  = "index:persistentVolumeClusterID"
 	vscClusterIDIndexName = "index:volumeSnapshotContentCSIDriver"
@@ -496,6 +497,10 @@ func (r *StorageClaimReconciler) getCephRBDStorageClass(data map[string]string) 
 		AllowVolumeExpansion: &allowVolumeExpansion,
 		Provisioner:          csi.GetRBDDriverName(),
 		Parameters:           data,
+	}
+
+	if r.storageClaim.Spec.EncryptionMethod != "" {
+		utils.AddAnnotation(storageClass, keyRotationAnnotation, utils.CronScheduleWeekly)
 	}
 	return storageClass
 }

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -43,6 +43,8 @@ const DesiredSubscriptionChannelAnnotationKey = "ocs.openshift.io/subscription.c
 
 const runCSIDaemonsetOnMaster = "RUN_CSI_DAEMONSET_ON_MASTER"
 
+const CronScheduleWeekly = "@weekly"
+
 // GetOperatorNamespace returns the namespace where the operator is deployed.
 func GetOperatorNamespace() string {
 	return os.Getenv(OperatorNamespaceEnvVar)


### PR DESCRIPTION
This PR adds the required EncrpytionKeyRotation annotations on RBD StorageClasses to automate key rotation operations.

The default schedule is: weekly