### PR TITLE
controllers: kernel mount options for cephfs Encryption in transit

### DIFF
--- a/controllers/storageclaim_controller.go
+++ b/controllers/storageclaim_controller.go
@@ -54,6 +54,8 @@ const (
 
 	pvClusterIDIndexName  = "index:persistentVolumeClusterID"
 	vscClusterIDIndexName = "index:volumeSnapshotContentCSIDriver"
+
+	kernelMountOptionsKey = "kernelmountoptions"
 )
 
 // StorageClaimReconciler reconciles a StorageClaim object
@@ -380,6 +382,9 @@ func (r *StorageClaimReconciler) reconcilePhases() (reconcile.Result, error) {
 					csiClusterConfigEntry.CephFS.SubvolumeGroup = data["subvolumegroupname"]
 					// delete groupname from data as its not required in storageclass
 					delete(data, "subvolumegroupname")
+					csiClusterConfigEntry.CephFS.KernelMountOptions = data[kernelMountOptionsKey]
+					// delete kernelmountoptions from data as its not required in storageclass
+					delete(data, kernelMountOptionsKey)
 					storageClass = r.getCephFSStorageClass(data)
 				} else if resource.Name == "ceph-rbd" {
 					storageClass = r.getCephRBDStorageClass(data)

--- a/pkg/csi/monconfigmap.go
+++ b/pkg/csi/monconfigmap.go
@@ -50,7 +50,8 @@ type CephRBDSpec struct {
 }
 
 type CephFSSpec struct {
-	SubvolumeGroup string `json:"subvolumeGroup,omitempty"`
+	SubvolumeGroup     string `json:"subvolumeGroup,omitempty"`
+	KernelMountOptions string `json:"kernelMountOptions,omitempty"`
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
support encryption in transit for cephfs when kernel mount option is set to secure. This information is recieved from provider and processed during storage claim creation.

The PR on OCS operator side is: https://github.com/red-hat-storage/ocs-operator/pull/2707