### PR TITLE
ci: use golangci-lint version from makefile

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,12 +18,16 @@ jobs:
         with:
             go-version-file: go.mod
 
+      - name: Source build env variables
+        run: |
+          grep -v '^#' hack/build.env >> $GITHUB_ENV
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or
           # v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: ${{ env.GO_LINT_IMG_TAG }}
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/hack/build.env
+++ b/hack/build.env
@@ -1,0 +1,4 @@
+# DO NOT COMMENT INLINE
+
+# linter version to use locally and in CI
+GO_LINT_IMG_TAG=v1.59.1

--- a/hack/make-project-vars.mk
+++ b/hack/make-project-vars.mk
@@ -1,3 +1,7 @@
+# all env from this file can be overwritten from command line if required
+# with "make <target> VAR=VALUE"
+include hack/build.env
+
 PROJECT_DIR := $(PWD)
 BIN_DIR := $(PROJECT_DIR)/bin
 
@@ -7,7 +11,6 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
 GO_LINT_IMG_LOCATION ?= golangci/golangci-lint
-GO_LINT_IMG_TAG ?= v1.59.2
 GO_LINT_IMG ?= $(GO_LINT_IMG_LOCATION):$(GO_LINT_IMG_TAG)
 
 ENVTEST_K8S_VERSION?=1.26


### PR DESCRIPTION
occasionally lint version used in CI (latest by default) gets ahead of version used locally, in addition to that, PRs against branches also are checked against latest linter which often forces to update unrelated parts of backports, this PR tries to always read the version from local vars and use that in CI.