### PR TITLE
hack: add verification of go deps in gh action

### DIFF
--- a/.github/workflows/verify-generated.yaml
+++ b/.github/workflows/verify-generated.yaml
@@ -8,16 +8,22 @@ on:
       - hack/**
       - Makefile
       - config/manager/csi-images.yaml
+      - go.mod
+      - go.sum
+      - vendor
   pull_request:
     branches: ['*']
     paths:
       - hack/**
       - Makefile
       - config/manager/csi-images.yaml
+      - go.mod
+      - go.sum
+      - vendor
 
 jobs:
   csi-images-manifest:
-    name: verify-csi-images-manifest
+    name: verify-generated-changes
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -25,5 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Verify changes to CSI images manifest
         run: make verify-csi-images-manifest
+
+      - name: Verify go deps
+        run: make godeps-verify

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ verify-csi-images-manifest: csi-images-manifest ## Verify csi-images-manifest ha
 		git diff -u $${CSI_IMAGES_MANIFEST}; \
 		exit 1; \
 	fi
-
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
@@ -58,6 +57,10 @@ lint: ## Run golangci-lint against code.
 
 godeps-update:  ## Run go mod tidy & vendor
 	go mod tidy && go mod vendor
+
+godeps-verify: godeps-update
+	@echo "Verifying go-deps"
+	./hack/godeps-verify.sh
 
 test-setup: godeps-update generate fmt vet envtest ## Run setup targets for tests
 

--- a/hack/godeps-verify.sh
+++ b/hack/godeps-verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+paths=('go.mod' 'go.sum' 'vendor/')
+
+if [[ -n "$(git status --porcelain "${paths[@]}")" ]]; then
+	git diff -u "${paths[@]}"
+	echo "Inconsistency found in dependency files. Run 'make update-go-deps' and commit results."
+	exit 1
+fi
+echo "Success: no out of source tree changes found for dependency files"


### PR DESCRIPTION
update Make file to add new targets to verify go deps and add it in the github action