### PR TITLE
hack: update csv timestamp only when there are changes in bundle

### DIFF
--- a/.github/workflows/verify-generated.yaml
+++ b/.github/workflows/verify-generated.yaml
@@ -40,3 +40,9 @@ jobs:
 
       - name: Verify go deps
         run: make godeps-verify
+
+      - name: Verify bundle
+        run: |
+          make bundle
+          msg='Uncommitted bundle changes. Run `make bundle` and commit results.'
+          git diff --exit-code bundle || (echo -e '\e[31m'"$msg"; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	yq -i '.dependencies[0].value.version = "'${CSI_ADDONS_PACKAGE_VERSION}'"' config/metadata/dependencies.yaml
 	cp config/metadata/* bundle/metadata/
 	$(OPERATOR_SDK) bundle validate ./bundle
+	hack/update-csv-timestamp.sh
 
 .PHONY: bundle-build
 bundle-build: bundle ## Build the bundle image.

--- a/hack/update-csv-timestamp.sh
+++ b/hack/update-csv-timestamp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git diff --quiet -I'^( )+createdAt: ' bundle
+if ((! $?)) ; then
+    git checkout --quiet bundle
+fi


### PR DESCRIPTION
This PR includes the following changes
1. add a script not to update the timestamp in the csv if there are no bundle changes
2. add ci action to verify bundle changes

### Why?
With operator-sdk 1.26+ every time we generate a new bundle, the createdAt field in the csv is updated. 
This means we have to create a manual backport even when there are no bundle changes hence, resetting the createdAt field if there are no changes in the bundle.

This PR also introduces a ci action to check whether there are any uncommitted bundle changes.
