### PR TITLE
controllers: deploy CSI if opted in

### DIFF
--- a/pkg/utils/csi.go
+++ b/pkg/utils/csi.go
@@ -9,7 +9,7 @@ import (
 )
 
 var DelegateCSI = func() bool {
-	return strings.ToLower(os.Getenv(CSIReconcileEnvVar)) == "delegate"
+	return strings.ToLower(os.Getenv(CSIReconcileEnvVar)) != "self"
 }()
 
 func ExtractMonitor(monitorData []byte) ([]string, error) {


### PR DESCRIPTION
by default delegate CSI management to ceph-csi-operator and only reconcile them directly if the env is set to `self`