### PR TITLE
makefile: update csi-addons bundle version from 0.9.0 to 0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	$(KUSTOMIZE) build $(MANIFEST_PATH) | sed "s|STATUS_REPORTER_IMAGE_VALUE|$(IMG)|g" | awk '{print}'| \
 		$(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) --extra-service-accounts="$$($(KUSTOMIZE) build $(MANIFEST_PATH) | $(YQ) 'select(.kind == "ServiceAccount") | .metadata.name' -N | paste -sd "," -)"
 	yq -i '.dependencies[0].value.packageName = "'${CSI_ADDONS_PACKAGE_NAME}'"' config/metadata/dependencies.yaml
-	yq -i '.dependencies[0].value.version = "'${CSI_ADDONS_PACKAGE_VERSION}'"' config/metadata/dependencies.yaml
+	yq -i '.dependencies[0].value.version = ">='${CSI_ADDONS_PACKAGE_VERSION}'"' config/metadata/dependencies.yaml
 	cp config/metadata/* bundle/metadata/
 	./hack/create-csi-images-manifest.sh
 	$(OPERATOR_SDK) bundle validate ./bundle

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2024-08-22T06:43:16Z"
+    createdAt: "2024-08-30T13:24:10Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: csi-addons
-      version: 0.9.0
+      version: '>=0.9.1'
   - type: olm.package
     value:
       packageName: cephcsi-operator

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: csi-addons
-      version: 0.9.0
+      version: '>=0.9.1'
   - type: olm.package
     value:
       packageName: cephcsi-operator

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -49,7 +49,7 @@ IMAGE_TAG ?= latest
 IMAGE_NAME ?= ocs-client-operator
 BUNDLE_IMAGE_NAME ?= $(IMAGE_NAME)-bundle
 CSI_ADDONS_BUNDLE_IMAGE_NAME ?= k8s-bundle
-CSI_ADDONS_BUNDLE_IMAGE_TAG ?= v0.9.0
+CSI_ADDONS_BUNDLE_IMAGE_TAG ?= v0.9.1
 CATALOG_IMAGE_NAME ?= $(IMAGE_NAME)-catalog
 
 OCS_CLIENT_CONSOLE_IMG_NAME ?= ocs-client-console
@@ -99,7 +99,7 @@ endif
 
 # csi-addons dependencies
 CSI_ADDONS_PACKAGE_NAME ?= csi-addons
-CSI_ADDONS_PACKAGE_VERSION ?= 0.9.0
+CSI_ADDONS_PACKAGE_VERSION ?= 0.9.1
 
 ## CSI driver images
 # The following variables define the default CSI container images to deploy


### PR DESCRIPTION
csi-addons 0.9.0 introduced a regression in their deployments by adding an extra prefix and 0.9.1 fixes that