### PR TITLE
Disable noobaa management on client for dev preview

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -813,7 +813,8 @@ func (c *OperatorConfigMapReconciler) getDeployCSIConfig() (bool, error) {
 func (c *OperatorConfigMapReconciler) getNoobaaSubManagementConfig() bool {
 	valAsString, ok := c.operatorConfigMap.Data[manageNoobaaSubKey]
 	if !ok {
-		return true
+		//while feature in dev preview returning false to disable feature by default.
+		return false
 	}
 	val, err := strconv.ParseBool(valAsString)
 	if err != nil {
@@ -821,7 +822,8 @@ func (c *OperatorConfigMapReconciler) getNoobaaSubManagementConfig() bool {
 			err,
 			"Unsupported value under manageNoobaaSubscription key",
 		)
-		return true
+		//while feature in dev preview returning false to disable feature by default.
+		return false
 	}
 	return val
 }


### PR DESCRIPTION
Disable env var default return value to false in order to not force noobaa management on the client while feature is in dev preview