### PR TITLE
bundle: add capabilities to csv

### DIFF
--- a/config/manifests/bases/ocs-client-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ocs-client-operator.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Deep Insights
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest


### PR DESCRIPTION
Levels defined:
1 - Basic Install
2 - Seamless Upgrades
3 - Full Lifecycle Management
4 - Deep Insights
5 - Autopilot

ocs & odf are on 4, client also ticks those boxes indirectly as the info sent from client is the main basis for alerting on provider and so choosing the same level.

Fix for bug https://bugzilla.redhat.com/show_bug.cgi?id=2303821