### PR TITLE
bundle: add default toleration to operators and cronjob

### DIFF
--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -72,3 +72,8 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: ocs-client-operator-controller-manager
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -96,3 +96,8 @@ spec:
           secretName: webhook-cert-secret
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -589,6 +589,14 @@ func (r *StorageClientReconciler) reconcileClientStatusReporterJob() (reconcile.
 							},
 							RestartPolicy:      corev1.RestartPolicyOnFailure,
 							ServiceAccountName: "ocs-client-operator-status-reporter",
+							Tolerations: []corev1.Toleration{
+								{
+									Effect:   corev1.TaintEffectNoSchedule,
+									Key:      "node.ocs.openshift.io/storage",
+									Operator: corev1.TolerationOpEqual,
+									Value:    "true",
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
all operators deployed as part of odf should tolerate this taint by default "node.ocs.openshift.io/storage=true:NoSchedule"