### PR TITLE
controllers: fix available crd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN make go-build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 COPY --from=builder /workspace/bin/status-reporter .

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2024-10-07T10:43:06Z"
+    createdAt: "2024-10-14T12:21:27Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -322,6 +322,17 @@ spec:
           - clusterresourcequotas
           verbs:
           - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ramendr.openshift.io
+          resources:
+          - drclusterconfigs
+          verbs:
+          - create
+          - delete
           - get
           - list
           - update

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,7 +104,6 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	storageclustersSelector := fields.SelectorFromSet(fields.Set{"metadata.name": "storageclusters.ocs.openshift.io"})
 	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -114,10 +113,6 @@ func main() {
 		LeaderElectionID:       "7cb6f2e5.ocs.openshift.io",
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
-				&extv1.CustomResourceDefinition{}: {
-					// only cache storagecluster crd
-					Field: storageclustersSelector,
-				},
 				&admrv1.ValidatingWebhookConfiguration{}: {
 					// only cache our validation webhook
 					Field: subscriptionwebhookSelector,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -284,6 +284,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ramendr.openshift.io
+  resources:
+  - drclusterconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/internal/controller/storageclaim_controller.go
+++ b/internal/controller/storageclaim_controller.go
@@ -147,6 +147,7 @@ func (r *StorageClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotcontents,verbs=get;list;watch
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=clientprofiles,verbs=get;list;update;create;watch;delete
+//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs,verbs=get;list;update;create;watch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/utils/predicates.go
+++ b/pkg/utils/predicates.go
@@ -19,13 +19,13 @@ func CrdCreateAndDeletePredicate(log *logr.Logger, crdName string, crdExists boo
 	return predicate.Funcs{
 		CreateFunc: func(_ event.CreateEvent) bool {
 			if !crdExists {
-				log.Info("CustomResourceDefinition %s was Created.", crdName)
+				log.Info("CustomResourceDefinition was Created.", "CustomResourceDefinition", crdName)
 			}
 			return !crdExists
 		},
 		DeleteFunc: func(_ event.DeleteEvent) bool {
 			if crdExists {
-				log.Info("CustomResourceDefinition %s was Deleted.", crdName)
+				log.Info("CustomResourceDefinition was Deleted.", "CustomResourceDefinition", crdName)
 			}
 			return crdExists
 		},


### PR DESCRIPTION
The PR does the following
1. gcr.io/distroless/static:nonroot does not allow us to run
bash scripts, since with available crd we are capturing the exit
via a bash script, moving to use
registry.access.redhat.com/ubi9/ubi-minimal as the base
2. remove caching only storageCluster crd
3. fix panic while logging