### PR TITLE
api: adding role and set correct name to get CRQ

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -397,6 +397,12 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - quota.openshift.io
+          resources:
+          - clusterresourcequotas
+          verbs:
+          - get
         serviceAccountName: ocs-client-operator-status-reporter
       deployments:
       - label:

--- a/config/rbac/status-reporter-clusterrole.yaml
+++ b/config/rbac/status-reporter-clusterrole.yaml
@@ -29,3 +29,9 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - quota.openshift.io
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -311,7 +311,7 @@ func (r *StorageClientReconciler) reconcilePhases() (ctrl.Result, error) {
 
 func (r *StorageClientReconciler) reconcileClusterResourceQuota(spec *quotav1.ClusterResourceQuotaSpec) error {
 	clusterResourceQuota := &quotav1.ClusterResourceQuota{}
-	clusterResourceQuota.Name = fmt.Sprintf("storage-client-%s-resourceqouta", utils.GetMD5Hash(r.storageClient.Name))
+	clusterResourceQuota.Name = utils.GetClusterResourceQuotaName(r.storageClient.Name)
 	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, clusterResourceQuota, func() error {
 
 		if err := r.own(clusterResourceQuota); err != nil {

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -166,3 +166,7 @@ func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) 
 	}
 	return nil
 }
+
+func GetClusterResourceQuotaName(name string) string {
+	return fmt.Sprintf("storage-client-%s-resourceqouta", GetMD5Hash(name))
+}

--- a/service/status-report/main.go
+++ b/service/status-report/main.go
@@ -207,7 +207,7 @@ func setClusterInformation(ctx context.Context, cl client.Client, status interfa
 
 func setStorageQuotaUtilizationRatio(ctx context.Context, cl client.Client, status interfaces.StorageClientStatus) {
 	clusterResourceQuota := &quotav1.ClusterResourceQuota{}
-	clusterResourceQuota.Name = status.GetClientName()
+	clusterResourceQuota.Name = utils.GetClusterResourceQuotaName(status.GetClientName())
 
 	// No need to check for NotFound because unlimited quota client will not have CRQ resource
 	if err := cl.Get(ctx, client.ObjectKeyFromObject(clusterResourceQuota), clusterResourceQuota); client.IgnoreNotFound(err) != nil {


### PR DESCRIPTION
- Adding a cluster role to get the cluster resource quota from a status reporter
- the name of CRQ is not always same as storage client so changing the logic as per the format