### PR TITLE
api: make inMaintenanceMode optional

### DIFF
--- a/api/v1alpha1/storageclient_types.go
+++ b/api/v1alpha1/storageclient_types.go
@@ -50,7 +50,7 @@ type StorageClientSpec struct {
 type StorageClientStatus struct {
 	Phase storageClientPhase `json:"phase,omitempty"`
 
-	InMaintenanceMode bool `json:"inMaintenanceMode"`
+	InMaintenanceMode bool `json:"inMaintenanceMode,omitempty"`
 
 	// ConsumerID will hold the identity of this cluster inside the attached provider cluster
 	ConsumerID string `json:"id,omitempty"`

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2024-11-22T06:22:20Z"
+    createdAt: "2024-11-25T13:55:27Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.

--- a/bundle/manifests/ocs.openshift.io_storageclients.yaml
+++ b/bundle/manifests/ocs.openshift.io_storageclients.yaml
@@ -69,8 +69,6 @@ spec:
                 type: boolean
               phase:
                 type: string
-            required:
-            - inMaintenanceMode
             type: object
         type: object
     served: true

--- a/config/crd/bases/ocs.openshift.io_storageclients.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclients.yaml
@@ -69,8 +69,6 @@ spec:
                 type: boolean
               phase:
                 type: string
-            required:
-            - inMaintenanceMode
             type: object
         type: object
     served: true


### PR DESCRIPTION
olm stops operator updates when a new field is introduced with a required qualifer, hence we need to make it optional