### PR TITLE
controllers: use semantic deepequal

### DIFF
--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"reflect"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -153,7 +153,7 @@ func CreateOrReplace(ctx context.Context, c client.Client, obj client.Object, f 
 		return err
 	}
 
-	if reflect.DeepEqual(existing, obj) {
+	if equality.Semantic.DeepEqual(existing, obj) {
 		return nil
 	}
 


### PR DESCRIPTION
The logs for operator had multiple StorageClaims reconcile for rbd type.
The VRC for flatten in rbd didn't have any annotation added to it due to which `reflect.DeepEqual` was treating it as difference and it was being created again and again. Hence moving to use `semantics.DeepQual` which treats empty and nil containers the same.
```
An empty slice *is* equal to a nil slice for our purposes; same for maps.

```
Ref: https://pkg.go.dev/k8s.io/apimachinery/third_party/forked/golang/reflect#Equalities.DeepEqual
