### PR TITLE
controllers: skip checking for vgsc if the crd is not present

### DIFF
--- a/internal/controller/storageclaim_controller.go
+++ b/internal/controller/storageclaim_controller.go
@@ -705,6 +705,9 @@ func (r *StorageClaimReconciler) hasVolumeSnapshotContents() (bool, error) {
 }
 
 func (r *StorageClaimReconciler) hasVolumeGroupSnapshotContents() (bool, error) {
+	if !r.AvailableCrds[VolumeGroupSnapshotClassCrdName] {
+		return false, nil
+	}
 	vscList := &groupsnapapi.VolumeGroupSnapshotContentList{}
 	if err := r.list(vscList, client.MatchingFields{vgscClusterIDIndexName: r.storageClaimHash}); err != nil {
 		return false, fmt.Errorf("failed to list volume group snapshot content resources: %v", err)


### PR DESCRIPTION
While offboarding the operator looks for VGSC's if the OCP feature gate is not enabled, the CRD won't be present and the operator won't proceed to offboarding. This PR checks if the VGSC CRD is present before looking for VGSC.