### PR TITLE
bundle: remove optional mount for nginx-configmap

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2025-03-10T11:31:35Z"
+    createdAt: "2025-04-01T10:21:29Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -559,7 +559,6 @@ spec:
                   secretName: ocs-client-operator-console-serving-cert
               - configMap:
                   name: ocs-client-operator-console-nginx-conf
-                  optional: true
                 name: ocs-client-operator-console-nginx-conf
               - emptyDir: {}
                 name: ocs-client-operator-console-nginx-log

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -54,7 +54,6 @@ spec:
         - name: ocs-client-operator-console-nginx-conf
           configMap:
             name: ocs-client-operator-console-nginx-conf
-            optional: true
         - name: ocs-client-operator-console-nginx-log
           emptyDir: {}
         - name: ocs-client-operator-console-nginx-tmp


### PR DESCRIPTION
when an optional mount with subPath is used we are consistently observing failure at kubelet.

Error: container create failed: mount `/var/lib/kubelet/pods/<uid>/ volume-subpaths/ ocs-client-operator-console-nginx-conf/ ocs-client-operator-console/1` to `etc/nginx/nginx.conf`: Not a directory

we no longer need an `optional` mount for this configMap which only delays the starting of the container until CM is available but we no longer hit above issue.