### PR TITLE
sync between csi deletion by rook and csi creation by csi-operator

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2025-04-01T10:21:29Z"
+    createdAt: "2025-04-05T10:29:50Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -96,6 +96,14 @@ spec:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
           verbs:
           - get
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,14 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - get


### PR DESCRIPTION
this is a tough find worthy of a explainer and here it goes

kubelet plugin registration mechanism:
watch a particular folder on node and for every sock creation send an rpc to get it registered and on sock deletion de-register the plugin

node driver registrar:
a sidecar in nodeplugin and on start create a sock when kubelet asks for the name gets the name from csi plugin and send to kubelet, when container is deleted this sidecar removes the sock (hostPath)

issue:
rook managed csi is running and already registered the csidrivers and on upgrade node registrar from csi-op managed csi tries to create the sock and doesn't error out as it already exists

however, due to the order of operations rook deletes it's csi and the sock in the host also gets deleted but node registrar doesn't create it again (as per design) and kubelet when trying to mount a volume on that node fails to get a handle on the csidriver as it was de-registered.

usual recommendation is restart of nodeplugin but in our case for many clusters getting upgraded it's not a good UX

fix:
wait for rook managed csi to go away before we create csi-op (driver) cr's for bringning the new csi pods

https://issues.redhat.com/browse/DFBUGS-2068