### PR TITLE
controllers: set csidriver.spec.seLinuxMount to true

### DIFF
--- a/pkg/templates/csi.go
+++ b/pkg/templates/csi.go
@@ -114,6 +114,7 @@ var CSIOperatorConfigSpec = csiopv1a1.OperatorConfigSpec{
 			Replicas: ptr.To(int32(2)),
 		},
 		NodePlugin: &csiopv1a1.NodePluginSpec{
+			EnableSeLinuxHostMount: ptr.To(true),
 			Resources: csiopv1a1.NodePluginResourcesSpec{
 				LogRotator: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{


### PR DESCRIPTION
when client-op was created this field probably didn't exist (1.25) and when migration to csi-op is carried out only the existing fields from code was transferred.

this is a hint for Linux kernel that each volume is independently accessible and seems to be related to ReadWriteOncePod feature as well.

seLinuxMount is set to true in the yamls deployed by all ceph-csi (repo) supported drivers.