### PR TITLE
controllers: read subscription channel from GetDesiredClientState rpc

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -401,7 +401,14 @@ func (r *storageClientReconcile) reconcilePhases() (ctrl.Result, error) {
 		}
 	}
 
+	update := false
+	if utils.AddAnnotation(&r.storageClient, utils.DesiredSubscriptionChannelAnnotationKey, storageClientResponse.ClientOperatorChannel) {
+		update = true
+	}
 	if utils.AddAnnotation(&r.storageClient, utils.DesiredConfigHashAnnotationKey, storageClientResponse.DesiredStateHash) {
+		update = true
+	}
+	if update {
 		if err := r.update(&r.storageClient); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to update StorageClient with desired config hash annotation: %v", err)
 		}

--- a/service/status-report/main.go
+++ b/service/status-report/main.go
@@ -122,16 +122,7 @@ func main() {
 		klog.Exitf("Failed to report status of storageClient %v: %v", storageClient.Status.ConsumerID, err)
 	}
 
-	updated := false
-	if utils.AddAnnotation(storageClient, utils.DesiredSubscriptionChannelAnnotationKey, statusResponse.DesiredClientOperatorChannel) {
-		updated = true
-	}
-
 	if utils.AddAnnotation(storageClient, utils.DesiredConfigHashAnnotationKey, statusResponse.DesiredConfigHash) {
-		updated = true
-	}
-
-	if updated {
 		if err := cl.Update(ctx, storageClient); err != nil {
 			klog.Exitf("Failed to annotate storageclient %q: %v", storageClient.Name, err)
 		}


### PR DESCRIPTION
move updating the channel annotation from heartbeat job to controller as the channel is already part of state hash and we reconcile when the hash changes.

Depends on #338 