### PR TITLE
controllers: disable csi ctrlPlugin hostNetwork for internal client

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -64,11 +64,12 @@ const (
 	operatorConfigMapName = "ocs-client-operator-config"
 	// ClusterVersionName is the name of the ClusterVersion object in the
 	// openshift cluster.
-	clusterVersionName     = "version"
-	manageNoobaaSubKey     = "manageNoobaaSubscription"
-	subscriptionLabelKey   = "managed-by"
-	subscriptionLabelValue = "webhook.subscription.ocs.openshift.io"
-	generateRbdOMapInfoKey = "generateRbdOMapInfo"
+	clusterVersionName                 = "version"
+	manageNoobaaSubKey                 = "manageNoobaaSubscription"
+	subscriptionLabelKey               = "managed-by"
+	subscriptionLabelValue             = "webhook.subscription.ocs.openshift.io"
+	generateRbdOMapInfoKey             = "generateRbdOMapInfo"
+	useHostNetworkForCsiControllersKey = "useHostNetworkForCsiControllers"
 
 	operatorConfigMapFinalizer = "ocs-client-operator.ocs.openshift.io/storageused"
 	subPackageIndexName        = "index:subscriptionPackage"
@@ -410,7 +411,8 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI() error {
 		if c.AvailableCrds[VolumeGroupSnapshotClassCrdName] {
 			csiOperatorConfig.Spec.DriverSpecDefaults.SnapshotPolicy = csiopv1a1.VolumeGroupSnapshotPolicy
 		}
-
+		csiCtrlPluginHostNetwork, _ := strconv.ParseBool(c.operatorConfigMap.Data[useHostNetworkForCsiControllersKey])
+		csiOperatorConfig.Spec.DriverSpecDefaults.ControllerPlugin.HostNetwork = ptr.To(csiCtrlPluginHostNetwork)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile csi operator config: %v", err)

--- a/pkg/templates/csi.go
+++ b/pkg/templates/csi.go
@@ -111,7 +111,8 @@ var CSIOperatorConfigSpec = csiopv1a1.OperatorConfigSpec{
 					},
 				},
 			},
-			Replicas: ptr.To(int32(2)),
+			Replicas:    ptr.To(int32(2)),
+			HostNetwork: ptr.To(true),
 		},
 		NodePlugin: &csiopv1a1.NodePluginSpec{
 			EnableSeLinuxHostMount: ptr.To(true),


### PR DESCRIPTION
Disable CSI controller plugin host network when the client operator is running on the local storage cluster and the storage cluster is not on host network