### PR TITLE
restrict manager to watch selective  namespaces

### DIFF
--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -37,6 +37,10 @@ const (
 	// which is the namespace where operator pod is deployed.
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which indicates any other namespace to watch for resources.
+	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+
 	// OperatorPodNameEnvVar is the constant for env variable OPERATOR_POD_NAME
 	OperatorPodNameEnvVar = "OPERATOR_POD_NAME"
 
@@ -61,6 +65,10 @@ const (
 // GetOperatorNamespace returns the namespace where the operator is deployed.
 func GetOperatorNamespace() string {
 	return os.Getenv(OperatorNamespaceEnvVar)
+}
+
+func GetWatchNamespace() string {
+	return os.Getenv(WatchNamespaceEnvVar)
 }
 
 func ValidateOperatorNamespace() error {


### PR DESCRIPTION
Currently, the manager watches for resources in all namespaces. This ends up causing a increase in memory usage which hinders the regular deployment and activity of the operator, leading to the operator getting killed due to insufficient memory. 
The current proposed fix ensures that the manager caches resources from namespaces where the operator is deployed or that are specified in  the `WATCH_NAMESPACE` env variable.

Fixes: [DFBUGS-2056](https://issues.redhat.com/browse/DFBUGS-2056)  

### Testing performed: 
-------------------------------------------------------------------------------------------------------------------------
After deploying the `ocs-client-operator`, various resources such as `ConfigMaps` and `Secrets` were created in a namespace different from the operator's own namespace.

* Behaviour without the fix: It was observed that the memory usage of the `ocs-client-operator` continuously increased over time, eventually leading to the pod being terminated with `exit code 137 (OOMKilled)` due to exceeding its `256Mi` memory limit.
```
Every 5.0s: oc adm top pod | grep ocs-client-o... Shravanis-MacBook-Pro.  
ocs-client-operator-controller-manager-548d95968b-wpz9c                 1m                            236Mi
```

*  Behaviour with the fix: After applying the fix, the memory usage of the `ocs-client-operator` remained stable, and the pod continued to run without issues.
```
Every 5.0s: oc adm top pod | grep ocs-client-o... Shravanis-MacBook-Pro.  
ocs-client-operator-controller-manager-548d95968b-wpz9c                 2m                            30Mi
```
