### PR TITLE
controllers: stop calling GetStorageConfig from status reporter

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2025-05-12T14:17:40Z"
+    createdAt: "2025-05-14T08:12:57Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -398,16 +398,6 @@ spec:
           - ocs.openshift.io
           resources:
           - storageclients
-          verbs:
-          - get
-          - list
-          - update
-        - apiGroups:
-          - ""
-          resourceNames:
-          - ceph-csi-configs
-          resources:
-          - configmaps
           verbs:
           - get
           - list

--- a/config/rbac/status-reporter-clusterrole.yaml
+++ b/config/rbac/status-reporter-clusterrole.yaml
@@ -12,16 +12,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    resourceNames:
-      - ceph-csi-configs
-    verbs:
-      - get
-      - list
-      - update
-  - apiGroups:
       - config.openshift.io
     resources:
       - clusterversions


### PR DESCRIPTION
Since we are sending the monips in the hash we no longer need to update the cephconnection from the status reporter, as a result, GetStorageConfig is no longer required from the status reporter

Fixes: https://issues.redhat.com/browse/DFBUGS-2359