### PR TITLE
controllers: query the csvname based on operator deployment owner

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -255,6 +255,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	podName, err := utils.GetOperatorPodName()
+	if err != nil {
+		setupLog.Error(err, "Failed to get operator pod name")
+	}
+
 	setupLog.Info("setting up webhook server")
 	hookServer := mgr.GetWebhookServer()
 
@@ -271,6 +276,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		OperatorNamespace: utils.GetOperatorNamespace(),
+		OperatorPodName:   podName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "StorageClient")
 		os.Exit(1)

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -60,6 +60,8 @@ const (
 	ExitCodeThatShouldRestartTheProcess = 42
 
 	OcsClientTimeout = 10 * time.Second
+
+	OperatorVersionEnvVar = "OPERATOR_VERSION"
 )
 
 // GetOperatorNamespace returns the namespace where the operator is deployed.
@@ -69,6 +71,14 @@ func GetOperatorNamespace() string {
 
 func GetWatchNamespace() string {
 	return os.Getenv(WatchNamespaceEnvVar)
+}
+
+func GetOperatorPodName() (string, error) {
+	podName := os.Getenv(OperatorPodNameEnvVar)
+	if podName == "" {
+		return "", fmt.Errorf("OPERATOR_POD_NAME env doesn't contain pod name")
+	}
+	return podName, nil
 }
 
 func ValidateOperatorNamespace() error {


### PR DESCRIPTION
finding the operator version based on csv is erroneous at times and especially during upgrades when there is a possibility of two CSVs with same prefix in various phases.

since we don't set a name for pod in deployment it'll result in usual k8s naming convention and using that we go from pod -> dep -> csv -> ver