### PR TITLE
Avoid updating empty channel on the storage client annotations

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -407,8 +407,10 @@ func (r *storageClientReconcile) reconcilePhases() (ctrl.Result, error) {
 	}
 
 	update := false
-	if utils.AddAnnotation(&r.storageClient, utils.DesiredSubscriptionChannelAnnotationKey, storageClientResponse.ClientOperatorChannel) {
-		update = true
+	if storageClientResponse.ClientOperatorChannel != "" {
+		if utils.AddAnnotation(&r.storageClient, utils.DesiredSubscriptionChannelAnnotationKey, storageClientResponse.ClientOperatorChannel) {
+			update = true
+		}
 	}
 	if utils.AddAnnotation(&r.storageClient, utils.DesiredConfigHashAnnotationKey, storageClientResponse.DesiredStateHash) {
 		update = true


### PR DESCRIPTION
In case of errors & unexpected situations the subscription channel returned  can be empty. We should not update the empty channel on the storageclient.