### PR TITLE
controllers: always set metadata for csi nodeplugin pods

### DIFF
--- a/pkg/templates/csi.go
+++ b/pkg/templates/csi.go
@@ -77,6 +77,7 @@ const CSIOperatorConfigName = "ceph-csi-operator-config"
 
 var CSIOperatorConfigSpec = csiopv1a1.OperatorConfigSpec{
 	DriverSpecDefaults: &csiopv1a1.DriverSpec{
+		EnableMetadata: ptr.To(true),
 		Log: &csiopv1a1.LogSpec{
 			Verbosity: 5,
 			Rotation: &csiopv1a1.LogRotationSpec{


### PR DESCRIPTION
setting the option makes csi to add metadata to the volumes created in ceph and until now this wasn't made default as there is a possibility that external ceph couldn't support it.

however, based on available docs this is supported all the way from RHCEPH 5 and current maintenance ODF version 4.15 supports RHCEPH 6.