### PR TITLE
bundle: disable noobaa from client clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,6 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	yq -i '.dependencies[0].value.packageName = "'${CSI_ADDONS_PACKAGE_NAME}'"' config/metadata/dependencies.yaml
 	yq -i '.dependencies[0].value.version = ">='${CSI_ADDONS_PACKAGE_VERSION}'"' config/metadata/dependencies.yaml
 	yq -i '.dependencies[1].value.version = ">='${CEPH_CSI_PACKAGE_VERSION}'"' config/metadata/dependencies.yaml
-	yq -i '.dependencies[2].value.version = ">='${NOOBAA_PACKAGE_VERSION}'"' config/metadata/dependencies.yaml
 	cp config/metadata/* bundle/metadata/
 	./hack/create-csi-images-manifest.sh
 	$(OPERATOR_SDK) bundle validate ./bundle

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2025-05-21T08:44:12Z"
+    createdAt: "2025-05-28T08:26:21Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -9,9 +9,5 @@ dependencies:
       version: '>=4.19.0'
   - type: olm.package
     value:
-      packageName: noobaa-operator
-      version: ">=5.19.0"
-  - type: olm.package
-    value:
       packageName: recipe
       version: "0.0.1"

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -9,9 +9,5 @@ dependencies:
       version: '>=4.19.0'
   - type: olm.package
     value:
-      packageName: noobaa-operator
-      version: ">=5.19.0"
-  - type: olm.package
-    value:
       packageName: recipe
       version: "0.0.1"

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -255,11 +255,13 @@ func (c *OperatorConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 
-		//only reconcile noobaa-operator for remote clusters
-		if c.getNoobaaSubManagementConfig() {
-			if err := c.reconcileNoobaaOperatorSubscription(); err != nil {
-				c.log.Error(err, "unable to reconcile Noobaa Operator subscription")
-				return ctrl.Result{}, err
+		//don't reconcile noobaa-operator for remote clusters
+		if false {
+			if c.getNoobaaSubManagementConfig() {
+				if err := c.reconcileNoobaaOperatorSubscription(); err != nil {
+					c.log.Error(err, "unable to reconcile Noobaa Operator subscription")
+					return ctrl.Result{}, err
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/DFBUGS-2640

Changes:
- Remove noobaa operator from olm dependencies
- Added bundle changes