### PR TITLE
DFBUGS-2364: [release-4.18] controllers: restrict manager to watch selective  namespaces

### DIFF
--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -37,6 +37,10 @@ const (
 	// which is the namespace where operator pod is deployed.
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which indicates any other namespace to watch for resources.
+	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+
 	// OperatorPodNameEnvVar is the constant for env variable OPERATOR_POD_NAME
 	OperatorPodNameEnvVar = "OPERATOR_POD_NAME"
 
@@ -61,6 +65,10 @@ const (
 // GetOperatorNamespace returns the namespace where the operator is deployed.
 func GetOperatorNamespace() string {
 	return os.Getenv(OperatorNamespaceEnvVar)
+}
+
+func GetWatchNamespace() string {
+	return os.Getenv(WatchNamespaceEnvVar)
 }
 
 func ValidateOperatorNamespace() error {


### PR DESCRIPTION
Cache resources from namespaces where the operator is deployed or that are specified in  the `WATCH_NAMESPACE` env variable.
(cherry picked from commit https://github.com/red-hat-storage/ocs-client-operator/commit/4531319c3f3a508008632d235069d979d38bbb81)

[Note: Raising a new PR for the correct version](https://github.com/red-hat-storage/ocs-client-operator/pull/387#issuecomment-2935151061)