### PR TITLE
ci: fix the paths in verify-generated action

### DIFF
--- a/.github/workflows/verify-generated.yaml
+++ b/.github/workflows/verify-generated.yaml
@@ -9,10 +9,9 @@ on:
     paths:
       - hack/**
       - Makefile
-      - config/manager/csi-images.yaml
+      - config/**
       - go.mod
-      - go.sum
-      - vendor
+      - api/go.mod
 jobs:
   csi-images-manifest:
     name: verify-generated-changes


### PR DESCRIPTION
we were skipping this action from being run unintentionally due to wrong paths configured