### PR TITLE
controllers: Update client sub only if client version < provider version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -408,6 +408,11 @@ func (r *storageClientReconcile) reconcilePhases() (ctrl.Result, error) {
 	}
 
 	update := false
+	if storageClientResponse.ProviderVersion != "" {
+		if utils.AddAnnotation(&r.storageClient, utils.ProviderVersionAnnotationKey, storageClientResponse.ProviderVersion) {
+			update = true
+		}
+	}
 	if storageClientResponse.ClientOperatorChannel != "" {
 		if utils.AddAnnotation(&r.storageClient, utils.DesiredSubscriptionChannelAnnotationKey, storageClientResponse.ClientOperatorChannel) {
 			update = true

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -45,6 +45,9 @@ const (
 
 	StatusReporterImageEnvVar = "STATUS_REPORTER_IMAGE"
 
+	// Value corresponding to annotation key has the provider version
+	ProviderVersionAnnotationKey = "ocs.openshift.io/provider.version"
+
 	// Value corresponding to annotation key has subscription channel
 	DesiredSubscriptionChannelAnnotationKey = "ocs.openshift.io/subscription.channel"
 


### PR DESCRIPTION
This is to avoid early update of client operator csv which can lead to the provider trailing behind the client operator which can cause upgrade deadlock.
Ref-https://issues.redhat.com/browse/DFBUGS-2502