### PR TITLE
csi: add secondary name check for ex-snapshotter

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2025-06-05T12:45:43Z"
+    createdAt: "2025-06-11T14:45:33Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -17,5 +17,5 @@ dependencies:
       version: "0.0.1"
   - type: olm.package
     value:
-      packageName: odf-snapshot-controller
+      packageName: odf-external-snapshotter-operator
       version: ">=4.20.0"

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -17,5 +17,5 @@ dependencies:
       version: "0.0.1"
   - type: olm.package
     value:
-      packageName: odf-snapshot-controller
+      packageName: odf-external-snapshotter-operator
       version: ">=4.20.0"

--- a/hack/build-catalog.sh
+++ b/hack/build-catalog.sh
@@ -10,7 +10,7 @@ ${OPM} render --output=yaml ${CSI_ADDONS_BUNDLE_IMG} > catalog/csi-adddons-bundl
 ${OPM} render --output=yaml ${CEPH_CSI_BUNDLE_IMG} > catalog/cephcsi-operator-bundle.yaml
 ${OPM} render --output=yaml ${RECIPE_BUNDLE_IMG} > catalog/recipe.yaml
 ${OPM} render --output=yaml ${NOOBAA_BUNDLE_IMG} > catalog/noobaa-operator-bundle.yaml
-${OPM} render --output=yaml ${SNAPSHOT_CONTROLLER_BUNDLE_IMG} > catalog/odf-snapshot-controller-bundle.yaml
+${OPM} render --output=yaml ${SNAPSHOT_CONTROLLER_BUNDLE_IMG} > catalog/odf-external-snapshotter-operator-bundle.yaml
 
 cat << EOF >> catalog/index.yaml
 ---
@@ -65,14 +65,14 @@ entries:
   - name: $RECIPE_BUNDLE_NAME.v$RECIPE_BUNDLE_VERSION
 ---
 defaultChannel: alpha
-name: $SNAPSHOT_CONTROLLER_BUNDLE_NAME
+name: $SNAPSHOT_CONTROLLER_PACKAGE_NAME
 schema: olm.package
 ---
 schema: olm.channel
-package: recipe
+package: odf-external-snapshotter-operator
 name: alpha
 entries:
-  - name: $SNAPSHOT_CONTROLLER_BUNDLE_NAME.v$SNAPSHOT_CONTROLLER_BUNDLE_VERSION
+  - name: $SNAPSHOT_CONTROLLER_PACKAGE_NAME.v$SNAPSHOT_CONTROLLER_PACKAGE_VERSION
 EOF
 
 ${OPM} validate catalog

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -138,6 +138,7 @@ CEPH_CSI_PACKAGE_VERSION ?= 4.19.0
 NOOBAA_PACKAGE_VERSION ?= 5.19.0
 
 # snapshot-controller dependencies
+SNAPSHOT_CONTROLLER_PACKAGE_NAME ?= odf-external-snapshotter-operator
 SNAPSHOT_CONTROLLER_PACKAGE_VERSION ?= 4.20.0
 
 # The following variables are here as a convenience for developers so we don't have

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -792,14 +792,14 @@ func (c *OperatorConfigMapReconciler) reconcileRecipeOperatorSubscription() erro
 }
 
 func (c *OperatorConfigMapReconciler) reconcileODFSnapshotterSubscription() error {
-	odfSnapshotterSubscription, err := c.getSubscriptionByPackageName("odf-snapshot-controller")
+	odfSnapshotterSubscription, err := c.getSubscriptionByPackageName("odf-external-snapshotter-operator")
 	if err != nil {
 		return err
 	}
 	if c.subscriptionChannel != "" && c.subscriptionChannel != odfSnapshotterSubscription.Spec.Channel {
 		odfSnapshotterSubscription.Spec.Channel = c.subscriptionChannel
 		if err := c.update(odfSnapshotterSubscription); err != nil {
-			return fmt.Errorf("failed to update subscription channel of 'odf-snapshot-controller' to %v: %v", c.subscriptionChannel, err)
+			return fmt.Errorf("failed to update subscription channel of 'odf-external-snapshotter-operator' to %v: %v", c.subscriptionChannel, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
add secondary name check for ex-snapshotter being "odf-external-snapshotter-operator"