### PR TITLE
[release-4.19] Set Consumer version to 4.18 until provider upgrade to 4.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/red-hat-storage/ocs-client-operator/api v0.0.0-00010101000000-000000000000
 	github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20250616153327-dc1da2c8e1b7
 	github.com/stretchr/testify v1.9.0
-	google.golang.org/grpc v1.70.0 // indirect
+	google.golang.org/grpc v1.70.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.32.3
 	k8s.io/apiextensions-apiserver v0.31.0


### PR DESCRIPTION
During an upgrade from 4.18 to 4.19, if the client side upgrades first, the 4.18 provider will block its own upgrade upon detecting that the client has a higher version. To avoid this deadlock, we intentionally set the StorageConsumer's operatorVersion at 4.18 even after the client upgrades to 4.19.

We detect whether the provider has upgraded to 4.19 using the GetDesiredClientState RPC. This RPC is not available in 4.18, so if it fails as Unimplemented, we assume the provider is still on 4.18 and apply the 4.18 version to the StorageConsumer.

During the period we can not avoid updating the operatorVersion. As if the operator version is empty in the Request it's set to N/A.
