### PR TITLE
Revert "DFBUGS-2365: [release-4.17] restrict manager to watch selective namespaces"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 
 	apiv1alpha1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-client-operator/internal/controller"
@@ -101,20 +100,6 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	storageclustersSelector := fields.SelectorFromSet(fields.Set{"metadata.name": "storageclusters.ocs.openshift.io"})
-
-	defaultNamespaces := map[string]cache.Config{}
-	operatorNamespace := utils.GetOperatorNamespace()
-	defaultNamespaces[operatorNamespace] = cache.Config{}
-
-	watchNamespace := utils.GetWatchNamespace()
-	if watchNamespace == "" {
-		setupLog.Info("No value for env WATCH_NAMESPACE is set. Manager will only watch for resources in the operator deployed namespace.")
-	} else {
-		for _, namespace := range strings.Split(watchNamespace, ",") {
-			defaultNamespaces[namespace] = cache.Config{}
-		}
-	}
-
 	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -133,7 +118,6 @@ func main() {
 					Field: subscriptionwebhookSelector,
 				},
 			},
-			DefaultNamespaces: defaultNamespaces,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookPort,

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -30,10 +30,6 @@ import (
 // which is the namespace where operator pod is deployed.
 const OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 
-// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
-// which indicates any other namespace to watch for resources.
-const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
-
 // OperatorPodNameEnvVar is the constant for env variable OPERATOR_POD_NAME
 const OperatorPodNameEnvVar = "OPERATOR_POD_NAME"
 
@@ -57,10 +53,6 @@ const CSIReconcileEnvVar = "CSI_RECONCILE"
 // GetOperatorNamespace returns the namespace where the operator is deployed.
 func GetOperatorNamespace() string {
 	return os.Getenv(OperatorNamespaceEnvVar)
-}
-
-func GetWatchNamespace() string {
-	return os.Getenv(WatchNamespaceEnvVar)
 }
 
 func ValidateOperatorNamespace() error {


### PR DESCRIPTION
Reverts red-hat-storage/ocs-client-operator#353

Reason: It has been merged for 4.17.7 but has been acked for 4.17.9. Have to push it to the right stream.