### PR TITLE
DFBUGS-2365: [release-4.17] restrict manager to watch selective namespaces

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	apiv1alpha1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-client-operator/internal/controller"
@@ -100,6 +101,20 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	storageclustersSelector := fields.SelectorFromSet(fields.Set{"metadata.name": "storageclusters.ocs.openshift.io"})
+
+	defaultNamespaces := map[string]cache.Config{}
+	operatorNamespace := utils.GetOperatorNamespace()
+	defaultNamespaces[operatorNamespace] = cache.Config{}
+
+	watchNamespace := utils.GetWatchNamespace()
+	if watchNamespace == "" {
+		setupLog.Info("No value for env WATCH_NAMESPACE is set. Manager will only watch for resources in the operator deployed namespace.")
+	} else {
+		for _, namespace := range strings.Split(watchNamespace, ",") {
+			defaultNamespaces[namespace] = cache.Config{}
+		}
+	}
+
 	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -118,6 +133,7 @@ func main() {
 					Field: subscriptionwebhookSelector,
 				},
 			},
+			DefaultNamespaces: defaultNamespaces,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookPort,

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -30,6 +30,10 @@ import (
 // which is the namespace where operator pod is deployed.
 const OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 
+// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+// which indicates any other namespace to watch for resources.
+const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+
 // OperatorPodNameEnvVar is the constant for env variable OPERATOR_POD_NAME
 const OperatorPodNameEnvVar = "OPERATOR_POD_NAME"
 
@@ -53,6 +57,10 @@ const CSIReconcileEnvVar = "CSI_RECONCILE"
 // GetOperatorNamespace returns the namespace where the operator is deployed.
 func GetOperatorNamespace() string {
 	return os.Getenv(OperatorNamespaceEnvVar)
+}
+
+func GetWatchNamespace() string {
+	return os.Getenv(WatchNamespaceEnvVar)
 }
 
 func ValidateOperatorNamespace() error {


### PR DESCRIPTION
Cache resources from namespaces where the operator is deployed or that are specified in the WATCH_NAMESPACE env variable.
(cherry picked from commit https://github.com/red-hat-storage/ocs-client-operator/commit/4531319c3f3a508008632d235069d979d38bbb81)

Note: Pushes changes reverted by #404 