### PR TITLE
DFBUGS-2366: [release-4.16] restrict manager to watch selective namespaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	apiv1alpha1 "github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-client-operator/controllers"
@@ -94,6 +95,20 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	storageclustersSelector := fields.SelectorFromSet(fields.Set{"metadata.name": "storageclusters.ocs.openshift.io"})
+
+	defaultNamespaces := map[string]cache.Config{}
+	operatorNamespace := utils.GetOperatorNamespace()
+	defaultNamespaces[operatorNamespace] = cache.Config{}
+
+	watchNamespace := utils.GetWatchNamespace()
+	if watchNamespace == "" {
+		setupLog.Info("No value for env WATCH_NAMESPACE is set. Manager will only watch for resources in the operator deployed namespace.")
+	} else {
+		for _, namespace := range strings.Split(watchNamespace, ",") {
+			defaultNamespaces[namespace] = cache.Config{}
+		}
+	}
+
 	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -112,6 +127,7 @@ func main() {
 					Field: subscriptionwebhookSelector,
 				},
 			},
+			DefaultNamespaces: defaultNamespaces,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookPort,

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -28,6 +28,10 @@ import (
 // which is the namespace where operator pod is deployed.
 const OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 
+// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+// which indicates any other namespace to watch for resources.
+const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
+
 // OperatorPodNameEnvVar is the constant for env variable OPERATOR_POD_NAME
 const OperatorPodNameEnvVar = "OPERATOR_POD_NAME"
 
@@ -44,6 +48,10 @@ const runCSIDaemonsetOnMaster = "RUN_CSI_DAEMONSET_ON_MASTER"
 // GetOperatorNamespace returns the namespace where the operator is deployed.
 func GetOperatorNamespace() string {
 	return os.Getenv(OperatorNamespaceEnvVar)
+}
+
+func GetWatchNamespace() string {
+	return os.Getenv(WatchNamespaceEnvVar)
 }
 
 func ValidateOperatorNamespace() error {


### PR DESCRIPTION
Cache resources from namespaces where the operator is deployed or that are specified in  the `WATCH_NAMESPACE` env variable. 
(manual cherry pick from commit 4531319)

Note: Proposes changes reverted by #405 