### PR TITLE
controllers: add watches for noobaa and remove reconciliation

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2025-07-01T12:48:21Z"
+    createdAt: "2025-07-03T11:25:18Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -244,7 +244,6 @@ spec:
           resources:
           - noobaas
           verbs:
-          - create
           - delete
           - get
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -207,7 +207,6 @@ rules:
   resources:
   - noobaas
   verbs:
-  - create
   - delete
   - get
   - list

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -81,6 +81,8 @@ const (
 	subPackageIndexName        = "index:subscriptionPackage"
 	csiImagesConfigMapLabel    = "ocs.openshift.io/csi-images-version"
 	cniNetworksAnnotationKey   = "k8s.v1.cni.cncf.io/networks"
+	noobaaCrdName              = "noobaas.noobaa.io"
+	noobaaCrName               = "noobaa-remote"
 )
 
 // OperatorConfigMapReconciler reconciles a ClusterVersion object
@@ -185,6 +187,17 @@ func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&admrv1.ValidatingWebhookConfiguration{}, enqueueConfigMapRequest, webhookPredicates).
 		Watches(&v1alpha1.StorageClient{}, enqueueConfigMapRequest, builder.WithPredicates(predicate.AnnotationChangedPredicate{}))
 
+	if c.AvailableCrds[noobaaCrdName] {
+		bldr.Watches(
+			&nbv1.NooBaa{},
+			enqueueConfigMapRequest,
+			builder.WithPredicates(
+				utils.NamePredicate(noobaaCrName),
+				predicate.GenerationChangedPredicate{},
+			),
+		)
+	}
+
 	return bldr.Complete(c)
 }
 
@@ -204,7 +217,7 @@ func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=operatorconfigs,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=drivers,verbs=get;list;update;create;watch;delete
-//+kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;delete;watch
+//+kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;watch;update;delete
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
@@ -1093,7 +1106,7 @@ func parseTolerations(csiPluginTolerations string) ([]corev1.Toleration, error) 
 
 func (c *OperatorConfigMapReconciler) removeNoobaa() error {
 	noobaa := &nbv1.NooBaa{}
-	noobaa.Name = "noobaa-remote"
+	noobaa.Name = noobaaCrName
 	noobaa.Namespace = c.OperatorNamespace
 
 	if err := c.get(noobaa); !meta.IsNoMatchError(err) && client.IgnoreNotFound(err) != nil {

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -36,7 +36,6 @@ import (
 	"github.com/go-logr/logr"
 	groupsnapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
-	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	providerClient "github.com/red-hat-storage/ocs-operator/services/provider/api/v4/client"
@@ -92,7 +91,6 @@ var (
 		&csiopv1a1.CephConnection{},
 		&csiopv1a1.ClientProfileMapping{},
 		&corev1.Secret{},
-		&nbv1.NooBaa{},
 		&storagev1.StorageClass{},
 		&snapapi.VolumeSnapshotClass{},
 		&replicationv1a1.VolumeReplicationClass{},
@@ -224,7 +222,6 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;create;update;watch;delete
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=cephconnections,verbs=get;list;update;create;watch;delete
-//+kubebuilder:rbac:groups=noobaa.io,resources=noobaas,verbs=get;list;create;update;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=clientprofilemappings,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=clientprofiles,verbs=get;list;update;create;watch;delete


### PR DESCRIPTION
requeue for storageclient owned noobaa and remove reconciliation in storageclient controller as older provider may still send noobaa and which the updated client shouldn't work on.