### PR TITLE
DFBUGS-3664:[release-4.19] skip webhook reconcile and desiredstate conditionally

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -30,6 +30,8 @@ import (
 	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
 	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 	"go.uber.org/multierr"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	csiopv1a1 "github.com/ceph/ceph-csi-operator/api/v1alpha1"
 	replicationv1a1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
@@ -383,6 +385,10 @@ func (r *storageClientReconcile) reconcilePhases() (ctrl.Result, error) {
 
 	storageClientResponse, err := externalClusterClient.GetDesiredClientState(r.ctx, r.storageClient.Status.ConsumerID)
 	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.FailedPrecondition {
+			r.log.Info("Client does not meet hub requirements, stopping reconciliation")
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{}, fmt.Errorf("failed to get StorageConfig: %v", err)
 	}
 

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -386,7 +386,7 @@ func (r *storageClientReconcile) reconcilePhases() (ctrl.Result, error) {
 	storageClientResponse, err := externalClusterClient.GetDesiredClientState(r.ctx, r.storageClient.Status.ConsumerID)
 	if err != nil {
 		if st, ok := status.FromError(err); ok && st.Code() == codes.FailedPrecondition {
-			r.log.Info("Client does not meet hub requirements, stopping reconciliation")
+			r.log.Info("Client does not meet hub requirements, stopping reconciliation", "reason", st.Message())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to get StorageConfig: %v", err)


### PR DESCRIPTION
backport of #434 #436 #437

### webhook:

when client-op runs in hubs odf-op can't change the sub of client-op. usually, the sub of client-op is changed when ocs-op provider-server sends info to change, however during the upgrade odf-op -> fails to update client-op -> ocs-op also gets stuck -> client-op webhook doesn't allow odf-op to change the sub resulting in upgrade deadlock.

now, ocs-op explicitly [sets](red-hat-storage/ocs-operator#3386) a value in client-op cm and ocs-op stops reconcile of webhook based on the set value.

### client upgrade before hub:

due to relaxing webhook as stated above, client-op can upgrade first since all the odf-deps start upgrading in parallel, to negate that client-op will stop the reconciliation if hub sends a specific grpc code till the hash changes which contains hub [version](red-hat-storage/ocs-operator#3386).

by above we alter the behavior of client-op conditionally.

