### PR TITLE
controllers: reverting check for driverSpecDefaults

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -503,7 +503,7 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 		driverSpecDefaults := csiOperatorConfig.Spec.DriverSpecDefaults
 		driverSpecDefaults.ImageSet = &corev1.LocalObjectReference{Name: cmName}
 		driverSpecDefaults.ClusterName = ptr.To(string(clusterVersion.Spec.ClusterID))
-		if c.AvailableCrds[VolumeGroupSnapshotClassCrdName] || c.AvailableCrds[OdfVolumeGroupSnapshotClassCrdName] {
+		if c.AvailableCrds[VolumeGroupSnapshotClassCrdName] {
 			driverSpecDefaults.SnapshotPolicy = csiopv1.VolumeGroupSnapshotPolicy
 		}
 		csiCtrlPluginHostNetwork, _ := strconv.ParseBool(c.operatorConfigMap.Data[useHostNetworkForCsiControllersKey])


### PR DESCRIPTION
Sets the SnapshotPolicy in `operatorconfig_controller` to be updated only when the (public) VolumeGroupSnapshotClass CRD exists.
