### PR TITLE
controllers: delete all noobaa csvs

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -215,7 +215,7 @@ func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=*
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch;update;delete
-//+kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=delete
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=delete;list
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=operatorconfigs,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=drivers,verbs=get;list;update;create;watch;delete
@@ -1162,40 +1162,49 @@ func (c *OperatorConfigMapReconciler) removeNoobaaOperator() error {
 		return nil
 	}
 
+	csvList := &metav1.PartialObjectMetadataList{}
+	csvList.SetGroupVersionKind(opv1a1.SchemeGroupVersion.WithKind("ClusterServiceVersion"))
+	if err := c.list(csvList, client.InNamespace(c.OperatorNamespace)); err != nil {
+		return fmt.Errorf("failed to list csv: %v", err)
+	}
+	mcgCsvList := utils.Filter(csvList.Items, func(csv metav1.PartialObjectMetadata) bool {
+		return strings.HasPrefix(csv.Name, "mcg-operator")
+	})
+	for i := range mcgCsvList {
+		csv := &mcgCsvList[i]
+		if index := slices.IndexFunc(
+			csv.OwnerReferences,
+			func(ref metav1.OwnerReference) bool {
+				return ref.Kind == "Subscription" && ref.Name == "odf-operator"
+			},
+		); index == -1 {
+			if csv.GetDeletionTimestamp().IsZero() {
+				if err := c.delete(csv); err != nil {
+					c.log.Error(err, "failed to delete noobaa operator csv")
+					return err
+				}
+			}
+		}
+	}
+
 	noobaaSubscription, err := c.getSubscriptionByPackageName("mcg-operator")
 	if client.IgnoreNotFound(err) != nil {
 		return err
 	} else if noobaaSubscription == nil {
 		return nil
 	}
-	index := slices.IndexFunc(
+	if index := slices.IndexFunc(
 		noobaaSubscription.OwnerReferences,
 		func(ref metav1.OwnerReference) bool {
 			return ref.Kind == "Subscription" && ref.Name == "odf-operator"
 		},
-	)
-	if index != -1 {
-		return nil
-	}
-
-	csv := &opv1a1.ClusterServiceVersion{}
-	csv.Name = noobaaSubscription.Status.InstalledCSV
-	csv.Namespace = c.OperatorNamespace
-	if csv.Name != "" {
-		if err := c.get(csv); client.IgnoreNotFound(err) != nil {
-			c.log.Error(err, "failed to get noobaa operator csv")
-			return err
-		} else if csv.UID != "" && csv.GetDeletionTimestamp().IsZero() {
-			if err := c.delete(csv); err != nil {
-				c.log.Error(err, "failed to delete noobaa operator csv")
+	); index == -1 {
+		if noobaaSubscription.GetDeletionTimestamp().IsZero() {
+			if err = c.delete(noobaaSubscription); err != nil {
 				return err
 			}
 		}
 	}
-	if noobaaSubscription.GetDeletionTimestamp().IsZero() {
-		if err = c.delete(noobaaSubscription); err != nil {
-			return err
-		}
-	}
+
 	return nil
 }

--- a/pkg/utils/slices.go
+++ b/pkg/utils/slices.go
@@ -34,3 +34,13 @@ func AssertEqual[T comparable](actual T, expected T, exitCode int) {
 		os.Exit(exitCode)
 	}
 }
+
+func Filter[T any](s []T, predicate func(T) bool) []T {
+	result := make([]T, 0, len(s))
+	for _, v := range s {
+		if predicate(v) {
+			result = append(result, v)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
There can be an edge case during upgrades where there are two csv for noobaa pointing to different versions. This might result in only one csv being marked for deletion. We should be removing all the csv if they are not owned by the odf-op subs