### PR TITLE
controllers: send the right clusterID to the provider

### DIFF
--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -187,7 +187,7 @@ func SetClusterInformation(
 	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(clusterVersion), clusterVersion); err != nil {
 		return fmt.Errorf("failed to get cluster version: %v", err)
 	}
-	status.SetClusterID(string(clusterVersion.UID))
+	status.SetClusterID(string(clusterVersion.Spec.ClusterID))
 
 	historyRecord := Find(clusterVersion.Status.History, func(record *configv1.UpdateHistory) bool {
 		return record.State == configv1.CompletedUpdate


### PR DESCRIPTION
The clusterID sent to the provider was incorrectly sent as clusterVersion.UID instead of clusterVersion.Spec.ClusterID.

Fixes: [DFBUGS-3995](https://issues.redhat.com/browse/DFBUGS-3995)