### PR TITLE
DFBUGS-1356:[release-4.18] controllers: add a info explicitly stating no user action

### DIFF
--- a/service/deployment-guard/main.go
+++ b/service/deployment-guard/main.go
@@ -95,7 +95,7 @@ func allowOperatorToRun(ctx context.Context, cl client.Client, namespace string)
 			klog.Info("StorageCluster CR does not exist")
 			return false
 		}
-		klog.Info("Checking if StorageCluster indicates ODF is deployed in provider mode")
+		klog.Info("Waiting on deployment mode verification, no user action needed.")
 		if storageClusters.Items[0].GetAnnotations()["ocs.openshift.io/deployment-mode"] != "provider" {
 			return false
 		}


### PR DESCRIPTION
it was observed that users is mistaking the log message and trying to speed up the operation by manually annotating the storagecluster with provider mode annotation even in non provider modes.