### PR TITLE
hack: update the binary name for ocs-client-op

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN make go-build
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 WORKDIR /
-COPY --from=builder /workspace/bin/manager .
+COPY --from=builder /workspace/bin/ocs-client-operator .
 COPY --from=builder /workspace/bin/status-reporter .
 COPY --from=builder /workspace/hack/entrypoint.sh entrypoint
 USER 65532:65532

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -3,7 +3,7 @@
 RESTART_EXIT_CODE=42
 
 while true; do
-    ./manager $@
+    ./ocs-client-operator $@
     EXIT_CODE=$?
     if [ $EXIT_CODE -ne $RESTART_EXIT_CODE ]; then
       exit $EXIT_CODE

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -7,5 +7,5 @@ export GO111MODULE=${GO111MODULE:-on}
 
 set -x
 
-go build -a -o ${GOBIN:-bin}/manager cmd/main.go
+go build -a -o ${GOBIN:-bin}/ocs-client-operator cmd/main.go
 go build -a -o ${GOBIN:-bin}/status-reporter ./service/status-report/main.go


### PR DESCRIPTION
Update the name of the ocs-client-op binary from "manager" to "ocs-client-operator"

Fixes: https://github.com/red-hat-storage/ocs-client-operator/issues/458