### PR TITLE
DFBUGS-5819: [release-4.19] controllers: create cronjob with tolerations set on client-op sub

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -64,8 +64,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-//go:embed pvc-rules.yaml
-var pvcPrometheusRules string
+var (
+	//go:embed pvc-rules.yaml
+	pvcPrometheusRules          string
+	subPackageIndexerRegistered bool
+)
 
 const (
 	operatorConfigMapName = "ocs-client-operator-config"
@@ -109,13 +112,8 @@ type OperatorConfigMapReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
-	if err := mgr.GetCache().IndexField(ctx, &opv1a1.Subscription{}, subPackageIndexName, func(o client.Object) []string {
-		if sub := o.(*opv1a1.Subscription); sub != nil {
-			return []string{sub.Spec.Package}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("unable to set up FieldIndexer for subscription package name: %v", err)
+	if err := addSubscriptionPackageIndexer(ctx, mgr); err != nil {
+		return err
 	}
 
 	clusterVersionPredicates := builder.WithPredicates(
@@ -919,7 +917,7 @@ func (c *OperatorConfigMapReconciler) reconcileSubscriptionValidatingWebhook() e
 
 func (c *OperatorConfigMapReconciler) reconcileClientOperatorSubscription() error {
 
-	clientSubscription, err := c.getSubscriptionByPackageName("ocs-client-operator")
+	clientSubscription, err := getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "ocs-client-operator")
 	if err != nil {
 		return err
 	}
@@ -942,9 +940,9 @@ func (c *OperatorConfigMapReconciler) reconcileClientOperatorSubscription() erro
 }
 
 func (c *OperatorConfigMapReconciler) reconcileNoobaaOperatorSubscription() error {
-	noobaaSubscription, err := c.getSubscriptionByPackageName("mcg-operator")
+	noobaaSubscription, err := getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "mcg-operator")
 	if kerrors.IsNotFound(err) {
-		noobaaSubscription, err = c.getSubscriptionByPackageName("noobaa-operator")
+		noobaaSubscription, err = getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "noobaa-operator")
 	}
 	if err != nil {
 		return err
@@ -959,9 +957,9 @@ func (c *OperatorConfigMapReconciler) reconcileNoobaaOperatorSubscription() erro
 }
 
 func (c *OperatorConfigMapReconciler) reconcileCSIAddonsOperatorSubscription() error {
-	addonsSubscription, err := c.getSubscriptionByPackageName("odf-csi-addons-operator")
+	addonsSubscription, err := getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "odf-csi-addons-operator")
 	if kerrors.IsNotFound(err) {
-		addonsSubscription, err = c.getSubscriptionByPackageName("csi-addons")
+		addonsSubscription, err = getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "csi-addons")
 	}
 	if err != nil {
 		return err
@@ -976,9 +974,9 @@ func (c *OperatorConfigMapReconciler) reconcileCSIAddonsOperatorSubscription() e
 }
 
 func (c *OperatorConfigMapReconciler) reconcileCephCSIOperatorSubscription() error {
-	cephCsiOperatorSubscription, err := c.getSubscriptionByPackageName("cephcsi-operator")
+	cephCsiOperatorSubscription, err := getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "cephcsi-operator")
 	if kerrors.IsNotFound(err) {
-		cephCsiOperatorSubscription, err = c.getSubscriptionByPackageName("ceph-csi-operator")
+		cephCsiOperatorSubscription, err = getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "ceph-csi-operator")
 	}
 	if err != nil {
 		return err
@@ -993,7 +991,7 @@ func (c *OperatorConfigMapReconciler) reconcileCephCSIOperatorSubscription() err
 }
 
 func (c *OperatorConfigMapReconciler) reconcileRecipeOperatorSubscription() error {
-	recipeOperatorSubscription, err := c.getSubscriptionByPackageName("recipe")
+	recipeOperatorSubscription, err := getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "recipe")
 	if err != nil {
 		return err
 	}
@@ -1040,12 +1038,18 @@ func (c *OperatorConfigMapReconciler) delete(obj client.Object, opts ...client.D
 	return nil
 }
 
-func (c *OperatorConfigMapReconciler) getSubscriptionByPackageName(pkgName string) (*opv1a1.Subscription, error) {
+func getSubscriptionByPackageName(
+	ctx context.Context,
+	kubeClient client.Client,
+	namespace string,
+	pkgName string,
+) (*opv1a1.Subscription, error) {
 	subList := &opv1a1.SubscriptionList{}
-	if err := c.list(
+	if err := kubeClient.List(
+		ctx,
 		subList,
 		client.MatchingFields{subPackageIndexName: pkgName},
-		client.InNamespace(c.OperatorNamespace),
+		client.InNamespace(namespace),
 		client.Limit(1),
 	); err != nil {
 		return nil, fmt.Errorf("failed to list subscriptions: %v", err)
@@ -1262,7 +1266,7 @@ func (c *OperatorConfigMapReconciler) removeNoobaaOperator() error {
 		}
 	}
 
-	noobaaSubscription, err := c.getSubscriptionByPackageName("mcg-operator")
+	noobaaSubscription, err := getSubscriptionByPackageName(c.ctx, c.Client, c.OperatorNamespace, "mcg-operator")
 	if client.IgnoreNotFound(err) != nil {
 		return err
 	} else if noobaaSubscription == nil {
@@ -1274,5 +1278,23 @@ func (c *OperatorConfigMapReconciler) removeNoobaaOperator() error {
 		}
 	}
 
+	return nil
+}
+
+func addSubscriptionPackageIndexer(ctx context.Context, mgr ctrl.Manager) error {
+	if subPackageIndexerRegistered {
+		return nil
+	}
+
+	if err := mgr.GetCache().IndexField(ctx, &opv1a1.Subscription{}, subPackageIndexName, func(o client.Object) []string {
+		if sub := o.(*opv1a1.Subscription); sub != nil {
+			return []string{sub.Spec.Package}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("unable to set up FieldIndexer for subscription package name: %v", err)
+	}
+
+	subPackageIndexerRegistered = true
 	return nil
 }

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -131,6 +131,9 @@ type storageClientReconcile struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
+	if err := addSubscriptionPackageIndexer(ctx, mgr); err != nil {
+		return err
+	}
 	if err := mgr.GetCache().IndexField(ctx, &corev1.PersistentVolume{}, pvClusterIDIndexName, func(o client.Object) []string {
 		pv := o.(*corev1.PersistentVolume)
 		if pv != nil &&
@@ -236,6 +239,7 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=groupsnapshot.storage.k8s.io,resources=volumegroupsnapshotcontents,verbs=get;list;watch
 //+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclaims,verbs=get;list;watch;delete;patch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch;
 
 func (r *StorageClientReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	handler := storageClientReconcile{StorageClientReconciler: r}
@@ -577,6 +581,11 @@ func (r *storageClientReconcile) offboardConsumer(externalClusterClient *provide
 }
 
 func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersion string) (reconcile.Result, error) {
+	clientSubscription, err := getSubscriptionByPackageName(r.ctx, r.Client, r.OperatorNamespace, "ocs-client-operator")
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	cronJob := &batchv1.CronJob{}
 	// maximum characters allowed for cronjob name is 52 and below interpolation creates 47 characters
 	cronJob.Name = fmt.Sprintf("storageclient-%s-status-reporter", utils.GetMD5Hash(r.storageClient.Name)[:16])
@@ -587,7 +596,7 @@ func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersio
 	var keepJobResourceSeconds int32 = 600
 	var reducedKeptSuccecsful int32 = 1
 
-	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, cronJob, func() error {
+	_, err = controllerutil.CreateOrUpdate(r.ctx, r.Client, cronJob, func() error {
 		if err := r.own(cronJob); err != nil {
 			return fmt.Errorf("failed to own cronjob: %v", err)
 		}
@@ -629,14 +638,17 @@ func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersio
 							},
 							RestartPolicy:      corev1.RestartPolicyOnFailure,
 							ServiceAccountName: "ocs-client-operator-status-reporter",
-							Tolerations: []corev1.Toleration{
-								{
-									Effect:   corev1.TaintEffectNoSchedule,
-									Key:      "node.ocs.openshift.io/storage",
-									Operator: corev1.TolerationOpEqual,
-									Value:    "true",
+							Tolerations: append(
+								[]corev1.Toleration{
+									{
+										Effect:   corev1.TaintEffectNoSchedule,
+										Key:      "node.ocs.openshift.io/storage",
+										Operator: corev1.TolerationOpEqual,
+										Value:    "true",
+									},
 								},
-							},
+								clientSubscription.Spec.Config.Tolerations...,
+							),
 						},
 					},
 				},


### PR DESCRIPTION
when tolerations are set on the client-op subscription olm automatically transfers that to deployment, thereby to the pod and we need to use the same tolerations for cronjob as well.