### PR TITLE
controllers: fix panic on resolving tolerations

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -53,6 +53,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -694,7 +695,7 @@ func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersio
 										Value:    "true",
 									},
 								},
-								clientSubscription.Spec.Config.Tolerations...,
+								ptr.Deref(clientSubscription.Spec.Config, opv1a1.SubscriptionConfig{}).Tolerations...,
 							),
 						},
 					},


### PR DESCRIPTION
subscription.Spec.Config is a pointer field which isn't always set on client only clusters.