### PR TITLE
Code Changes When OBC CRD Not Installed

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -218,32 +218,29 @@ func main() {
 	}
 
 	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
+
+	// apiclient.New() returns a client without cache. cache is not initialized before mgr.Start()
+	// we need this because we need to watch for CRDs the operator is dependent on
+	apiClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		setupLog.Error(err, "Unable to get API client")
+		os.Exit(1)
+	}
+	availCrds, err := getAvailableCRDNames(context.Background(), apiClient)
+	if err != nil {
+		setupLog.Error(err, "Unable get a list of available CRD names")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "7cb6f2e5.ocs.openshift.io",
-		Cache: cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&admrv1.ValidatingWebhookConfiguration{}: {
-					// only cache our validation webhook
-					Field: subscriptionwebhookSelector,
-				},
-				// Watch ObjectBucketClaim and OBC-related resources in all namespaces so OBC controller reconciles regardless of WATCH_NAMESPACE.
-				// Empty ByObject would be defaulted to DefaultNamespaces; explicitly set NamespaceAll to avoid that.
-				&nbv1.ObjectBucketClaim{}: {
-					Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
-				},
-				&corev1.ConfigMap{}: {
-					Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
-				},
-				&corev1.Secret{}: {
-					Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
-				},
-			},
-			DefaultNamespaces: defaultNamespaces,
-		},
+		Cache:                  buildCacheAvailableCRDs(availCrds, subscriptionwebhookSelector, defaultNamespaces),
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookPort,
 			CertDir: "/etc/tls/private",
@@ -264,22 +261,6 @@ func main() {
 	err = utils.ValidateStausReporterImage()
 	if err != nil {
 		setupLog.Error(err, "unable to validate status reporter image")
-		os.Exit(1)
-	}
-
-	// apiclient.New() returns a client without cache. cache is not initialized before mgr.Start()
-	// we need this because we need to watch for CRDs the operator is dependent on
-	apiClient, err := client.New(mgr.GetConfig(), client.Options{
-		Scheme: mgr.GetScheme(),
-	})
-	if err != nil {
-		setupLog.Error(err, "Unable to get Client")
-		os.Exit(1)
-	}
-
-	availCrds, err := getAvailableCRDNames(context.Background(), apiClient)
-	if err != nil {
-		setupLog.Error(err, "Unable get a list of available CRD names")
 		os.Exit(1)
 	}
 
@@ -348,12 +329,14 @@ func main() {
 		}
 	}
 
-	if err = (&controller.ObcReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ObjectBucketClaim")
-		os.Exit(1)
+	if availCrds[controller.ObjectBucketClaimCrdName] {
+		if err = (&controller.ObcReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ObjectBucketClaim")
+			os.Exit(1)
+		}
 	}
 
 	setupLog.Info("starting manager")
@@ -375,4 +358,34 @@ func getAvailableCRDNames(ctx context.Context, cl client.Client) (map[string]boo
 		crdExist[crdList.Items[i].Name] = true
 	}
 	return crdExist, nil
+}
+
+func buildCacheAvailableCRDs(
+	availCrds map[string]bool,
+	subscriptionwebhookSelector fields.Selector,
+	defaultNamespaces map[string]cache.Config,
+) cache.Options {
+	cacheAvailableCrd := cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&admrv1.ValidatingWebhookConfiguration{}: {
+				// only cache our validation webhook
+				Field: subscriptionwebhookSelector,
+			},
+			&corev1.ConfigMap{}: {
+				Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
+			},
+			&corev1.Secret{}: {
+				Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
+			},
+		},
+		DefaultNamespaces: defaultNamespaces,
+	}
+	// Watch ObjectBucketClaim in all namespaces so OBC controller reconciles regardless of WATCH_NAMESPACE.
+	// Empty ByObject would be defaulted to DefaultNamespaces; explicitly set NamespaceAll to avoid that.
+	if availCrds[controller.ObjectBucketClaimCrdName] {
+		cacheAvailableCrd.ByObject[&nbv1.ObjectBucketClaim{}] = cache.ByObject{
+			Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
+		}
+	}
+	return cacheAvailableCrd
 }

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -86,6 +86,8 @@ const (
 
 	VolumeGroupSnapshotClassCrdName    = "volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io"
 	OdfVolumeGroupSnapshotClassCrdName = "volumegroupsnapshotclasses.groupsnapshot.storage.openshift.io"
+	ObjectBucketClaimCrdName           = "objectbucketclaims.objectbucket.io"
+	ObjectBucketCrdName                = "objectbuckets.objectbucket.io"
 )
 
 var (
@@ -204,6 +206,7 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&batchv1.CronJob{}).
 		Owns(&quotav1.ClusterResourceQuota{}, builder.WithPredicates(generationChangePredicate)).
 		Owns(&corev1.Secret{}).
+		Owns(&corev1.ConfigMap{}).
 		Owns(&csiopv1.CephConnection{}, builder.WithPredicates(generationChangePredicate)).
 		Owns(&csiopv1.ClientProfileMapping{}, builder.WithPredicates(generationChangePredicate)).
 		Owns(&storagev1.StorageClass{}).
@@ -228,6 +231,7 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.cache = mgr.GetCache()
 	r.crdsBeingWatched.Store(VolumeGroupSnapshotClassCrdName, false)
 	r.crdsBeingWatched.Store(OdfVolumeGroupSnapshotClassCrdName, false)
+	r.crdsBeingWatched.Store(ObjectBucketCrdName, false)
 
 	return err
 }
@@ -305,6 +309,11 @@ func (r *storageClientReconcile) reconcileDynamicWatches() error {
 	if err := r.reconcileOdfVolumeGroupSnapshot(); err != nil {
 		return err
 	}
+
+	if err := r.setupObjectBucketWatch(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -417,6 +426,46 @@ func (r *storageClientReconcile) reconcileOdfVolumeGroupSnapshot() error {
 		return fmt.Errorf("unable to set up FieldIndexer for VGSC csi driver name: %v", err)
 	}
 	r.crdsBeingWatched.Store(OdfVolumeGroupSnapshotClassCrdName, true)
+	return nil
+}
+
+func (r *storageClientReconcile) setupObjectBucketWatch() error {
+	if watchExists, foundCrd := r.crdsBeingWatched.Load(ObjectBucketCrdName); !foundCrd || watchExists.(bool) {
+		return nil
+	}
+
+	crd := &extv1.CustomResourceDefinition{}
+	crd.Name = ObjectBucketCrdName
+	if err := r.get(crd); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	if crd.UID == "" {
+		return nil
+	}
+	if !crdEstablished(crd) {
+		return nil
+	}
+
+	// establish a watch
+	if err := r.controller.Watch(
+		source.Kind(
+			r.cache,
+			client.Object(&nbv1.ObjectBucket{}),
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, o client.Object) []ctrl.Request {
+				owner := metav1.GetControllerOf(o)
+				if owner != nil &&
+					owner.Kind == "StorageClient" &&
+					owner.APIVersion == v1alpha1.GroupVersion.String() {
+					return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: owner.Name}}}
+				}
+				return nil
+			}),
+		),
+	); err != nil {
+		return fmt.Errorf("failed to setup dynamic watch on %s: %v", crd.Name, err)
+	}
+
+	r.crdsBeingWatched.Store(ObjectBucketCrdName, true)
 	return nil
 }
 
@@ -790,6 +839,10 @@ func (r *storageClientReconcile) hasOdfVolumeGroupSnapshotContents(clientProfile
 func (r *storageClientReconcile) hasObjectbucketClaims() (bool, error) {
 	obcList := &nbv1.ObjectBucketClaimList{}
 	if err := r.list(obcList, client.MatchingLabels{storageClientNameLabel: r.storageClient.Name}, client.Limit(1)); err != nil {
+		if meta.IsNoMatchError(err) {
+			r.log.Info("ObjectBucketClaim CRD is not installed, skipping object bucket claim check")
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to list object bucket claim resources: %v", err)
 	}
 	return len(obcList.Items) != 0, nil
@@ -965,4 +1018,16 @@ func (r *storageClientReconcile) getOperatorVersion() (string, error) {
 		return "", fmt.Errorf("failed to get csv: %v", err)
 	}
 	return csv.Spec.Version.String(), nil
+}
+
+// crdEstablished reports whether the CRD is served by the apiserver (status.conditions Established=True).
+// A CRD object can exist before the REST mapping for its resource is available.
+func crdEstablished(crd *extv1.CustomResourceDefinition) bool {
+	for i := range crd.Status.Conditions {
+		c := crd.Status.Conditions[i]
+		if c.Type == extv1.Established && c.Status == extv1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### Describe the problem
Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)
This PR adds the code in case the OBC CRD was not installed - it is related to PRs: #520 and #531
Waiting for PR #541 to be merged for the RBAC changes in the storage client reconcile.

### Explain the changes
1. In main - add the OBC controller only if the CRDs of OBC and OB were installed on the cluster.
2. In main - add OBC in all namespaces to the manager cache only if the CRDs of OBC was installed on the cluster. For this, I had to move the existing code so I will have the `availCrds` earlier.
3. In storage client controller - In case the offboarding occurs when there is no CRDs of OBC and OB were installed on the cluster, add the case of `meta.IsNoMatchError`.
4. In storage client controller - add watches (using `own`) on the configmap that was missing, and a conditional watch on OB if the CRD was installed.

### Issues: 
List og GAPs:
1. The cache of secret and config map should be:
- any config map and secret in the operator namespace
- any config map and secret with label key app and label value noobaa in all namespaces
reference:
https://github.com/red-hat-storage/ocs-client-operator/blob/804973cdf1a9a200bf5f2cc51923e058d3552479/cmd/main.go#L238-L243

2. In this PR, I added watches of resources owned by the storage client - config map and OB. There was a question raised about whether we should also add for OBC (currently, OBC does not have the owner reference of the storage client).
3. We want to avoid pod deletion in case the installation was done after the pod started. We might try to have the OBC controller with a different approach of watching the OBCs and the OBC CRDs (dynamic, like it is in storageclient).

### Testing Instructions:
#### Manual Test:
1. Client cluster: Check if you have OBC CRD on the cluster (if you have - delete them): `oc get crd | grep objectbucket.io`
2. Client cluster: Check the pod status `Running`: `oc get pods -n openshift-storage-client | grep ocs-client-operator-controller-manager`
Note: before adding this change it was `CrashLoopBackOff` and inside the logs it was:
```
oc logs -n openshift-storage-client ocs-client-operator-controller-manager-b87657db6-tkcxh -f
2026-03-26T07:19:03Z	INFO	setup	No value for env WATCH_NAMESPACE is set. Manager will only watch for resources in the operator deployed namespace.
2026-03-26T07:19:03Z	ERROR	setup	unable to create manager	{"error": "failed to determine if *v1alpha1.ObjectBucketClaim is namespaced: failed to get restmapping: no matches for kind \"ObjectBucketClaim\" in version \"objectbucket.io/v1alpha1\""}
main.main
	/workspace/cmd/main.go:253
runtime.main
	/usr/local/go/src/runtime/proc.go:283
```
3. Onboarding of storage client using the web console:
- Provider cluster: Storage -> storage consumers (left pane) -> click on "Create StorageConsumer" and fill in the name and unlimited quota option. Then pass the details from: (1) generate client token and (2) endpoint from `oc get storagecluster ocs-storagecluster -n openshift-storage -o yaml | grep storageProviderEndpoint`
- Client cluster: installed operators -> click on OpenShift Data Foundation Client -> Storage Client tab -> click on "Create StorageClient", fill in the name and the endpoint from the provider cluster details above.
4. Client Cluster: Offboarding of storage client using the web console: installed operators -> click on OpenShift Data Foundation Client -> Storage Client tab. From the storage client list, click on the option to delete the storage client. In the logs, we should not see any errors.

Note: as the controller of OBC was set in main (start the run of the pod) only in case CRDs of OBC and OB were installed on the cluster, so after install of CRD, one should delete the pod to have the OBC controller.