### PR TITLE
metrics: cephfs pv and vgsc count

### DIFF
--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -5,6 +5,7 @@ metadata:
     app: ocs-client-operator
   name: metrics
   namespace: system
+# should be in sync with pkg/templates/metricsservice.go
 spec:
   ports:
   - name: metrics

--- a/go.mod
+++ b/go.mod
@@ -116,8 +116,8 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.3 // indirect
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.3
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -765,6 +765,14 @@ func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersio
 											Name:  utils.OperatorVersionEnvVar,
 											Value: operatorVersion,
 										},
+										{
+											Name:  utils.MetricsServiceNameEnvVar,
+											Value: templates.MetricsServiceName,
+										},
+										{
+											Name:  utils.MetricsPortEnvVar,
+											Value: strconv.Itoa(int(templates.MetricsServicePort)),
+										},
 									},
 								},
 							},

--- a/pkg/templates/metricsservice.go
+++ b/pkg/templates/metricsservice.go
@@ -1,0 +1,9 @@
+package templates
+
+const (
+	// should be <namePrefix from config/default/kustomization.yaml><.metadata.name from config/default/metrics_service.yaml>
+	MetricsServiceName = "ocs-client-operator-metrics"
+
+	// should match .spec.ports[0].port from config/default/metrics_service.yaml
+	MetricsServicePort int32 = 8080
+)

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -67,6 +67,9 @@ const (
 	OcsClientTimeout = 10 * time.Second
 
 	OperatorVersionEnvVar = "OPERATOR_VERSION"
+
+	MetricsServiceNameEnvVar = "METRICS_SERVICE_NAME"
+	MetricsPortEnvVar        = "METRICS_PORT"
 )
 
 // GetOperatorNamespace returns the namespace where the operator is deployed.

--- a/service/status-report/main.go
+++ b/service/status-report/main.go
@@ -18,8 +18,12 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"math"
+	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
@@ -27,6 +31,9 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	providerclient "github.com/red-hat-storage/ocs-operator/services/provider/api/v4/client"
 	"github.com/red-hat-storage/ocs-operator/services/provider/api/v4/interfaces"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,6 +91,20 @@ func main() {
 		klog.Exitf("%s env var not set", utils.OperatorVersionEnvVar)
 	}
 
+	metricsServiceName, isSet := os.LookupEnv(utils.MetricsServiceNameEnvVar)
+	if !isSet {
+		klog.Exitf("%s env var not set", utils.MetricsServiceNameEnvVar)
+	}
+
+	metricsPortStr, isSet := os.LookupEnv(utils.MetricsPortEnvVar)
+	if !isSet || metricsPortStr == "" {
+		klog.Exitf("%s env var not set", utils.MetricsPortEnvVar)
+	}
+	metricsPort, err := strconv.Atoi(metricsPortStr)
+	if err != nil {
+		klog.Exitf("Failed to parse %s: %v", utils.MetricsPortEnvVar, err)
+	}
+
 	storageClient := &v1alpha1.StorageClient{}
 	storageClient.Name = storageClientName
 
@@ -112,6 +133,8 @@ func main() {
 	status.SetClientName(storageClientName)
 	status.SetClientID(string(storageClient.UID))
 	setStorageQuotaUtilizationRatio(ctx, cl, status)
+	metricsEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/metrics", metricsServiceName, operatorNamespace, metricsPort)
+	setCephFsMetrics(status, metricsEndpoint, storageClientName)
 
 	if err := utils.SetClusterInformation(ctx, cl, status); err != nil {
 		klog.Warningf("Failed to set cluster information: %v", err)
@@ -146,5 +169,65 @@ func setStorageQuotaUtilizationRatio(ctx context.Context, cl client.Client, stat
 			status.SetStorageQuotaUtilizationRatio(math.Min(ratio, 1.0))
 		}
 	}
+}
 
+const (
+	cephFsPVCountMetric   = "ocs_client_operator_cephfs_pv_count"
+	cephFsVSCCountMetric = "ocs_client_operator_cephfs_volume_snapshot_content_count"
+)
+
+func setCephFsMetrics(status interfaces.StorageClientStatus, metricsEndpoint, storageClientName string) {
+	metricFamilies, err := fetchMetrics(metricsEndpoint)
+	if err != nil {
+		klog.Warningf("Failed to fetch metrics: %v", err)
+		return
+	}
+
+	if count, err := findMetricValue(metricFamilies, cephFsPVCountMetric, storageClientName); err != nil {
+		klog.Warningf("Failed to get CephFS PV count from metrics: %v", err)
+	} else {
+		status.SetCephFsPVCount(uint32(count))
+	}
+
+	if count, err := findMetricValue(metricFamilies, cephFsVSCCountMetric, storageClientName); err != nil {
+		klog.Warningf("Failed to get CephFS VolumeSnapshotContent count from metrics: %v", err)
+	} else {
+		status.SetCephFsVolumeSnapshotContentCount(uint32(count))
+	}
+}
+
+func fetchMetrics(endpoint string) (map[string]*dto.MetricFamily, error) {
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metrics from %s: %v", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("metrics endpoint returned status %d", resp.StatusCode)
+	}
+
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	return parser.TextToMetricFamilies(resp.Body)
+}
+
+func findMetricValue(metricFamilies map[string]*dto.MetricFamily, metricName, storageClientName string) (float64, error) {
+	mf, ok := metricFamilies[metricName]
+	if !ok {
+		return 0, fmt.Errorf("metric %q not found", metricName)
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == "storage_client" && lp.GetValue() == storageClientName {
+				if gauge := m.GetGauge(); gauge != nil {
+					return gauge.GetValue(), nil
+				}
+				return 0, fmt.Errorf("metric %q with storage_client=%q is not a gauge", metricName, storageClientName)
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("metric %q with storage_client=%q not found", metricName, storageClientName)
 }


### PR DESCRIPTION
Extend the status-reporter CronJob to report the count of CephFS
PV and VolumeSnapshotContent resources to the storage provider via gRPC
as part of the client status report. 


https://redhat.atlassian.net/browse/RHSTOR-8682