### PR TITLE
Gap - Update `buildCacheAvailableCRDs` Function

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,6 +55,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -219,8 +220,6 @@ func main() {
 		}
 	}
 
-	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
-
 	// apiclient.New() returns a client without cache. cache is not initialized before mgr.Start()
 	// we need this because we need to watch for CRDs the operator is dependent on
 	apiClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
@@ -242,7 +241,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "7cb6f2e5.ocs.openshift.io",
-		Cache:                  buildCacheAvailableCRDs(availCrds, subscriptionwebhookSelector, defaultNamespaces),
+		Cache:                  buildCacheAvailableCRDs(availCrds, defaultNamespaces, operatorNamespace),
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookPort,
 			CertDir: "/etc/tls/private",
@@ -380,9 +379,17 @@ func getAvailableCRDNames(ctx context.Context, cl client.Client) (map[string]boo
 
 func buildCacheAvailableCRDs(
 	availCrds map[string]bool,
-	subscriptionwebhookSelector fields.Selector,
 	defaultNamespaces map[string]cache.Config,
+	operatorNamespace string,
 ) cache.Options {
+	subscriptionwebhookSelector := fields.SelectorFromSet(fields.Set{"metadata.name": templates.SubscriptionWebhookName})
+	noobaaLabelSelector := labels.SelectorFromSet(labels.Set{"app": "noobaa"})
+	configMapAndSecretCacheByNamespace := map[string]cache.Config{
+		operatorNamespace: {},
+		cache.AllNamespaces: {
+			LabelSelector: noobaaLabelSelector,
+		},
+	}
 	cacheAvailableCrd := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
 			&admrv1.ValidatingWebhookConfiguration{}: {
@@ -390,10 +397,10 @@ func buildCacheAvailableCRDs(
 				Field: subscriptionwebhookSelector,
 			},
 			&corev1.ConfigMap{}: {
-				Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
+				Namespaces: configMapAndSecretCacheByNamespace,
 			},
 			&corev1.Secret{}: {
-				Namespaces: map[string]cache.Config{corev1.NamespaceAll: {}},
+				Namespaces: configMapAndSecretCacheByNamespace,
 			},
 		},
 		DefaultNamespaces: defaultNamespaces,


### PR DESCRIPTION
### Describe the problem
Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)
It fixes a change that was added in #520 and was raised in PR #539 (see [comment](https://github.com/red-hat-storage/ocs-client-operator/pull/539#issuecomment-4154280336)), which was mentioned as a gap in the PR description of #539.

### Explain the changes
1. In main - Update `buildCacheAvailableCRDs` function:
- any config map and secret in the operator namespace
- any config map and secret with label key app and label value noobaa in all namespaces

### Testing Instructions:
1. Manual Test: Only tested that the manager got started with the code changes.
2. Automatic test: Used an AI-generated script for listing OBC creation - so we would have a secret and a configmap with a label key app and value noobaa that would be listed. Attaching output:
```
cache-scope-test: list API checks passed
operator namespace: "openshift-storage-client"
  ConfigMaps (all): 20
  Secrets    (all): 23
cluster-wide with label "app=noobaa":
  ConfigMaps: 1
  Secrets:    1
distinct ConfigMap keys (operator-ns all ∪ cluster app=noobaa): 21
distinct Secret keys    (operator-ns all ∪ cluster app=noobaa): 24
```