### PR TITLE
Fix - Avoid Pod Deletion When NooBaa OBC CRD Is Installed

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -318,6 +318,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
+	shutdownContainer := func() {
+		cancel()
+	}
+
 	if err = (&controller.OperatorConfigMapReconciler{
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
@@ -340,6 +346,15 @@ func main() {
 		}
 	}
 
+	if err = (&controller.CrdsPresenceReconciler{
+		Client:            mgr.GetClient(),
+		AvailableCrds:     availCrds,
+		ShutdownContainer: shutdownContainer,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "CrdsPresence")
+		os.Exit(1)
+	}
+
 	if availCrds[controller.ObjectBucketClaimCrdName] {
 		if err = (&controller.ObcReconciler{
 			Client: mgr.GetClient(),
@@ -355,7 +370,7 @@ func main() {
 	metrics.Registry.MustRegister(alertCollector, resourceCollector)
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/internal/controller/crds_presence_controller.go
+++ b/internal/controller/crds_presence_controller.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"context"
+	"slices"
+
+	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
+
+	"github.com/go-logr/logr"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// crdsWatchedForPresenceRestart lists CRDs whose install/removal must match process startup
+// (manager cache and conditional controller registration; see cmd/main.go).
+// IMPORTANT - only add the cases where the dynamic watch for the CRD did not match the case.
+var crdsWatchedForPresenceRestart = []string{
+	ObjectBucketClaimCrdName,
+	MaintenanceModeCRDName,
+}
+
+type CrdsPresenceReconciler struct {
+	client.Client
+	AvailableCrds     map[string]bool
+	ShutdownContainer func()
+	log               logr.Logger
+}
+
+func (r *CrdsPresenceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("CrdsPresence").
+		For(
+			&extv1.CustomResourceDefinition{},
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(func(obj client.Object) bool {
+					return slices.Contains(crdsWatchedForPresenceRestart, obj.GetName())
+				}),
+				utils.EventTypePredicate(true, false, true, false),
+			),
+		).
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+func (r *CrdsPresenceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.log = ctrl.LoggerFrom(ctx).WithName("CrdsPresence")
+
+	for _, name := range crdsWatchedForPresenceRestart {
+		crd := &metav1.PartialObjectMetadata{}
+		crd.SetGroupVersionKind(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+		crd.Name = name
+		if err := r.Get(ctx, client.ObjectKeyFromObject(crd), crd); client.IgnoreNotFound(err) != nil {
+			r.log.Error(err, "Failed to get CRD", "CRD", crd.Name)
+			return ctrl.Result{}, err
+		}
+		presentNow := crd.UID != ""
+		if r.AvailableCrds[name] != presentNow {
+			r.log.Info("CRD presence changed, will restart container",
+				"presence at manager start", r.AvailableCrds[name],
+				"presence now", presentNow,
+			)
+			r.ShutdownContainer()
+			return ctrl.Result{}, nil
+		}
+	}
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -322,15 +322,6 @@ func (c *OperatorConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	c.log = log.FromContext(ctx, "OperatorConfigMap", req)
 	c.log.Info("Reconciling OperatorConfigMap")
 
-	crd := &metav1.PartialObjectMetadata{}
-	crd.SetGroupVersionKind(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
-	crd.Name = MaintenanceModeCRDName
-	if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); client.IgnoreNotFound(err) != nil {
-		c.log.Error(err, "Failed to get CRD", "CRD", crd.Name)
-		return reconcile.Result{}, err
-	}
-	utils.AssertEqual(c.AvailableCrds[crd.Name], crd.UID != "", utils.ExitCodeThatShouldRestartTheProcess)
-
 	c.operatorConfigMap = &corev1.ConfigMap{}
 	c.operatorConfigMap.Name = req.Name
 	c.operatorConfigMap.Namespace = req.Namespace


### PR DESCRIPTION
### Describe the problem
Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)
It fixes a change that was added in #539 (see [comment](https://github.com/red-hat-storage/ocs-client-operator/pull/539#issuecomment-4166071032)), which was mentioned as a gap in the PR description.

Note: I could not have a full dynamic OBC CRD and OBC watch since the cache was set at start, from what I checked, it can be done, but then I would have a different cache for the OBCs to be watched, and it gets more complicated when we need to GET or UPDATE the OBCs. To avoid pod deletion, I used process exit - reference:
https://github.com/red-hat-storage/ocs-client-operator/blob/dd10c95aad5569c6d235b167f3febf36ffd6fa5c/internal/controller/operatorconfigmap_controller.go#L349

### Explain the changes
1. In main - set the context with cancel and defer the cancel, define the function for container shutdown that would use the cancel call. We're using the cancel instead of the previous exit code because we want a graceful exit. 
2. Added a new controller that is triggered by created and deleted events only of CRDs with an opt-in list, because we want, wherever possible, to use dynamic watch (see example of OB in storage client controller) - it is the solution where we have a controller that has its main watch on a CR - OBC controller and MaintenanceMode controller.
3. Remove the process exit that we had in operatorconfigmap_controller related to MaintenanceMode CRD presence change.

### Issues: [DFBUGS-6494](https://redhat.atlassian.net/browse/DFBUGS-6494)

### Testing Instructions:
#### Manual Test:
1. Client cluster: Check if you have OBC CRD on the cluster (if you have - delete them): `oc get crd | grep objectbucket.io`
2. Check the status of the pod - should be running (`oc get pods -n openshift-storage-client | grep ocs-client-operator-controller-manager`)
3. Install NooBaa OBC and OB CRDs:
- `kubectl apply -f noobaa-operator/deploy/obc/objectbucket.io_objectbucketclaims_crd.yaml.`
- `kubectl apply -f noobaa-operator/deploy/obc/objectbucket.io_objectbuckets_crd.yaml`
This can also be done with ODF-CLI: `bin/odf object enable remote-obc -n openshift-storage-client` (I build the CLI for arm arch)
4. You would see in the logs that the container was shut down and the pod was restarted (see [comment](https://github.com/red-hat-storage/ocs-client-operator/pull/556#issuecomment-4280160424)).
5. Apply OBC yaml and check in the logs that the reconcile was started and Notify was called (you can also check on the provider cluster that the OBC was created).

Note: I also downloaded MaintenanceMode CRD ([link](https://github.com/RamenDR/ramen/blob/main/config/crd/bases/ramendr.openshift.io_maintenancemodes.yaml)) and applied it to see the container shutdown using `kubectl apply -f ~/Downloads/ramendr.openshift.io_maintenancemodes.yaml`