### PR TITLE
controllers: remove nginx pod restart behaviour on config update

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2026-04-30T07:33:13Z"
+    createdAt: "2026-05-13T10:42:29Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -502,13 +502,42 @@ spec:
                 app.kubernetes.io/name: ocs-client-operator-console
             spec:
               containers:
-              - image: quay.io/ocs-dev/ocs-client-console:latest
+              - command:
+                - /bin/sh
+                - -c
+                - |
+                  (
+                    echo "Waiting for Nginx master process to start."
+                    until nginx -s reload > /dev/null 2>&1; do
+                      sleep 1
+                    done
+
+                    LAST_HASH=$(md5sum /opt/app-root/etc/nginx.d/*.conf 2>/dev/null | sort | md5sum)
+                    echo "Nginx is up. Monitoring config changes."
+
+                    while true; do
+                      CURRENT_HASH=$(md5sum /opt/app-root/etc/nginx.d/*.conf 2>/dev/null | sort | md5sum)
+                      if [ "$CURRENT_HASH" != "$LAST_HASH" ]; then
+                        if nginx -t && nginx -s reload; then
+                          LAST_HASH="$CURRENT_HASH"
+                        fi
+                      fi
+                      sleep 45
+                    done
+                  ) &
+
+                  if [ -x /usr/libexec/s2i/run ]; then
+                    exec /usr/libexec/s2i/run
+                  else
+                    exec nginx -g "daemon off;"
+                  fi
+                image: quay.io/ocs-dev/ocs-client-console:latest
                 livenessProbe:
                   httpGet:
                     path: /plugin-manifest.json
                     port: 9001
                     scheme: HTTPS
-                  initialDelaySeconds: 1000
+                  initialDelaySeconds: 180
                   periodSeconds: 60
                 name: ocs-client-operator-console
                 ports:
@@ -533,10 +562,6 @@ spec:
                 - mountPath: /var/serving-cert
                   name: ocs-client-operator-console-serving-cert
                   readOnly: true
-                - mountPath: /etc/nginx/nginx.conf
-                  name: ocs-client-operator-console-nginx-conf
-                  readOnly: true
-                  subPath: nginx.conf
                 - mountPath: /opt/app-root/etc/nginx.d
                   name: ocs-client-operator-console-nginx-conf
                   readOnly: true

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -15,6 +15,35 @@ spec:
       containers:
         - name: ocs-client-operator-console
           image: ocs-client-operator-console:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              (
+                echo "Waiting for Nginx master process to start."
+                until nginx -s reload > /dev/null 2>&1; do
+                  sleep 1
+                done
+
+                LAST_HASH=$(md5sum /opt/app-root/etc/nginx.d/*.conf 2>/dev/null | sort | md5sum)
+                echo "Nginx is up. Monitoring config changes."
+
+                while true; do
+                  CURRENT_HASH=$(md5sum /opt/app-root/etc/nginx.d/*.conf 2>/dev/null | sort | md5sum)
+                  if [ "$CURRENT_HASH" != "$LAST_HASH" ]; then
+                    if nginx -t && nginx -s reload; then
+                      LAST_HASH="$CURRENT_HASH"
+                    fi
+                  fi
+                  sleep 45
+                done
+              ) &
+
+              if [ -x /usr/libexec/s2i/run ]; then
+                exec /usr/libexec/s2i/run
+              else
+                exec nginx -g "daemon off;"
+              fi
           resources:
             limits:
               cpu: "250m"
@@ -27,7 +56,7 @@ spec:
               path: /plugin-manifest.json
               port: 9001
               scheme: HTTPS
-            initialDelaySeconds: 1000
+            initialDelaySeconds: 180
             periodSeconds: 60
           ports:
             - containerPort: 9001
@@ -43,10 +72,6 @@ spec:
           volumeMounts:
             - name: ocs-client-operator-console-serving-cert
               mountPath: /var/serving-cert
-              readOnly: true
-            - name: ocs-client-operator-console-nginx-conf
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
               readOnly: true
             - name: ocs-client-operator-console-nginx-conf
               mountPath: /opt/app-root/etc/nginx.d

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -864,13 +864,7 @@ func (c *OperatorConfigMapReconciler) ensureConsolePlugin() error {
 	}
 
 	if nginxConfigMapResult == controllerutil.OperationResultCreated || nginxConfigMapResult == controllerutil.OperationResultUpdated {
-		c.log.Info("nginx ConfigMap data changed, restarting console pod to pick up new config")
-		// Console pod must restart (or nginx must reload) to pick up updated mounted config files.
-		// Restart failures are currently logged only. If restart fails once and config does not change again,
-		// subsequent reconciles will not retry because this block is gated by data-diff check.
-		// ToDo: If issue is prominent, explore reliable retry semantics, like restart based on marker/hash or graceful nginx reload.
-		// Note: checksum rollout via Deployment pod-template annotation is not reliable as Deployment is currently OLM/CSV-owned.
-		c.restartConsolePodsByLabel()
+		c.log.Info("nginx ConfigMap updated with new config, console pod will reload nginx automatically")
 	}
 
 	consoleService := console.GetService(c.ConsolePort, c.OperatorNamespace)
@@ -903,28 +897,6 @@ func (c *OperatorConfigMapReconciler) ensureConsolePlugin() error {
 	}
 
 	return nil
-}
-
-func (c *OperatorConfigMapReconciler) restartConsolePodsByLabel() {
-	podList := &corev1.PodList{}
-	if err := c.list(
-		podList,
-		client.InNamespace(c.OperatorNamespace),
-		client.MatchingLabels{console.AppNameLabelKey: console.DeploymentName},
-	); err != nil {
-		c.log.Error(err, "failed to list console pods by label selector", "namespace", c.OperatorNamespace)
-		return
-	}
-	if len(podList.Items) == 0 {
-		c.log.Info("no console pods found for restart", "namespace", c.OperatorNamespace)
-		return
-	}
-	for i := range podList.Items {
-		pod := &podList.Items[i]
-		if err := c.delete(pod); err != nil {
-			c.log.Error(err, "failed to delete console pod", "pod", pod.Name, "namespace", c.OperatorNamespace)
-		}
-	}
 }
 
 func (c *OperatorConfigMapReconciler) buildDesiredNginxDataWithProxies() (map[string]string, error) {
@@ -1014,7 +986,7 @@ func (c *OperatorConfigMapReconciler) buildS3EndpointProxyConfigForClient(unique
 		exposeAsKeys = append(exposeAsKeys, exposeAs)
 	}
 	// Processing endpoints in a fixed order so the generated nginx config "string" wouldn't change unless the actual endpoint data changed.
-	// This is to avoid unnecessary pod restarts, since restarts are triggered when changes are detected.
+	// This avoids unnecessary ConfigMap updates and nginx reloads.
 	sort.Strings(exposeAsKeys)
 	for _, exposeAs := range exposeAsKeys {
 		cfg := endpoints[exposeAs]

--- a/internal/controller/operatorconfigmap_controller_test.go
+++ b/internal/controller/operatorconfigmap_controller_test.go
@@ -297,12 +297,12 @@ func TestParseEndpointConfigs(t *testing.T) {
 
 func TestBuildS3EndpointProxyConfigForClient(t *testing.T) {
 	tests := []struct {
-		name                  string
-		secretData            map[string][]byte
-		endpoints             map[string]s3EndpointConfig
-		expectedIncludes      []string
-		expectedExcludes      []string
-		expectErr             bool
+		name             string
+		secretData       map[string][]byte
+		endpoints        map[string]s3EndpointConfig
+		expectedIncludes []string
+		expectedExcludes []string
+		expectErr        bool
 	}{
 		{
 			name: "builds config for valid https endpoints only",

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -117,18 +117,6 @@ func GetNginxProxyConf(uniqueIdentifier, exposeAs, endpointURL, endpointHost, ce
 	return sb.String(), nil
 }
 
-func GetNginxConfConfigMap(namespace string) *apiv1.ConfigMap {
-	return &apiv1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-nginx-conf", DeploymentName),
-			Namespace: namespace,
-		},
-		Data: map[string]string{
-			"nginx.conf": nginxRootConf,
-		},
-	}
-}
-
 func getConsolePluginProxy(port int32, serviceNamespace string) []consolev1.ConsolePluginProxy {
 	return []consolev1.ConsolePluginProxy{
 		{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6311

### Testing:
_On an existing 4.22 cluster (operator already deployed), updated CSV with custom image and updated volume mounts for the console pod -_

**Client Console pod (successful nginx config reload and expected traffic logs):**

> 10.129.2.2 - - [15/Apr/2026:08:17:24 +0000] "GET /plugin-manifest.json HTTP/1.1" 200 4228 "-" "kube-probe/1.34" "-"
> 10.128.0.96 - - [15/Apr/2026:08:17:29 +0000] "GET /plugin-manifest.json HTTP/1.1" 200 4228 "https://console-openshift-console.apps.DOMAIN.devcluster.openshift.com/k8s/ns/openshift-storage/pods/ocs-client-operator-controller-manager-587d977c7d-9tgnd/logs" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36" "223.177.68.17"
> nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
> nginx: configuration file /etc/nginx/nginx.conf test is successful
> 2026/04/15 08:17:34 [notice] 216#216: signal process started
> 10.128.0.96 - - [15/Apr/2026:08:17:43 +0000] "GET /vendors-node_modules_aws-sdk_client-iam_dist-es_IAMClient_js-node_modules_aws-sdk_client-iam_-7a941c-chunk.js HTTP/1.1" 200 704083 "https://console-openshift-console.apps.DOMAIN.devcluster.openshift.com/odf/object-storage" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36" "223.177.68.17"
> 10.128.0.96 - - [15/Apr/2026:08:17:54 +0000] "GET /ocs-s3-endpoints-list-8c8886f6-fb43-4d5c-9ccf-ebd6676e3ac4/noobaaS3/?max-buckets=100&x-id=ListBuckets HTTP/1.1" 200 338 "https://console-openshift-console.apps.DOMAIN.devcluster.openshift.com/odf/object-storage/buckets" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36" "223.177.68.17, 10.128.2.8"
> 10.128.0.96 - - [15/Apr/2026:08:17:59 +0000] "GET /plugin-manifest.json HTTP/1.1" 200 4228 "https://console-openshift-console.apps.DOMAIN.devcluster.openshift.com/k8s/ns/openshift-storage/pods/ocs-client-operator-controller-manager-587d977c7d-9tgnd/logs" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36" "223.177.68.17"


**Client Operator pod (nginx ConfigMap updated info and other expected logs):**

> 2026-04-15T08:11:13Z	INFO	Reconciling OperatorConfigMap	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "updated", "name": "ocs-client-operator-console-nginx-conf"}
> 2026-04-15T08:11:13Z	INFO	nginx ConfigMap updated with new config, console pod will reload nginx automatically	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "updated", "name": "ocs-client-operator-console"}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "updated", "name": "odf-client-console"}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "updated", "name": "ceph-csi-op-scc"}
> 2026-04-15T08:11:13Z	INFO	Cluster is running in DualReplica topology (TwoNodeFenced)	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "DualReplica": false}
> 2026-04-15T08:11:13Z	INFO	searching for the most compatible CSI image version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "CSI": "4.20", "Platform": "4.21.0"}
> 2026-04-15T08:11:13Z	INFO	searching for the most compatible CSI image version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "CSI": "4.17", "Platform": "4.21.0"}
> 2026-04-15T08:11:13Z	INFO	searching for the most compatible CSI image version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "CSI": "4.19", "Platform": "4.21.0"}
> 2026-04-15T08:11:13Z	INFO	searching for the most compatible CSI image version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "CSI": "4.18", "Platform": "4.21.0"}
> 2026-04-15T08:11:13Z	INFO	searching for the most compatible CSI image version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "CSI": "4.22", "Platform": "4.21.0"}
> 2026-04-15T08:11:13Z	INFO	skipping imagesets with version greater than platform version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}}
> 2026-04-15T08:11:13Z	INFO	searching for the most compatible CSI image version	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "CSI": "4.16", "Platform": "4.21.0"}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "unchanged", "name": "ceph-csi-operator-config"}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "unchanged", "name": "openshift-storage.rbd.csi.ceph.com"}
> 2026-04-15T08:11:13Z	INFO	successfully created or updated	{"controller": "OperatorConfigMapReconciler", "namespace": "openshift-storage", "name": "ocs-client-operator-config", "reconcileID": "708af3fc-6988-4b07-8a79-573a106badc6", "OperatorConfigMap": {"name":"ocs-client-operator-config","namespace":"openshift-storage"}, "operation": "unchanged", "name": "openshift-storage.cephfs.csi.ceph.com"}

**Console (Object Browser):**

<img width="1721" height="903" alt="Screenshot 2026-04-15 at 1 48 00 PM" src="https://github.com/user-attachments/assets/fbfb98d0-52ca-4918-b61f-3e477215e02c" />