### PR TITLE
csi: add SCC to the nvmeof service accounts

### DIFF
--- a/pkg/templates/csi.go
+++ b/pkg/templates/csi.go
@@ -68,6 +68,8 @@ func SetSecurityContextConstraintsDesiredState(scc *secv1.SecurityContextConstra
 		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-cephfs-nodeplugin-sa", ns),
 		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-nfs-ctrlplugin-sa", ns),
 		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-nfs-nodeplugin-sa", ns),
+		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-nvmeof-ctrlplugin-sa", ns),
+		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-nvmeof-nodeplugin-sa", ns),
 		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-rbd-ctrlplugin-sa", ns),
 		fmt.Sprintf("system:serviceaccount:%s:ceph-csi-rbd-nodeplugin-sa", ns),
 	}


### PR DESCRIPTION
The NVMe-oF ServiceAccounts need an SCC so that they can be used on OpenShift.

Updates: [DFBUGS-6396](https://redhat.atlassian.net/browse/DFBUGS-6396) [DFBUGS-6397](https://redhat.atlassian.net/browse/DFBUGS-6397)