### PR TITLE
Fix - OBC Controller: Finish Reconcile instead of Error Reconcile

### DIFF
--- a/internal/controller/obc_controller.go
+++ b/internal/controller/obc_controller.go
@@ -100,6 +100,12 @@ func (r *obcReconcile) reconcilePhases() (ctrl.Result, error) {
 		return reconcile.Result{}, fmt.Errorf("failed to get StorageClient: %w", err)
 	}
 
+	if storageClient == nil {
+		r.log.Info("StorageClass is not owned by a StorageClient; skipping OBC reconciliation",
+			"storageClassName", r.obc.Spec.StorageClassName)
+		return reconcile.Result{}, nil
+	}
+
 	ocsProviderClient, err := providerClient.NewProviderClient(r.ctx, storageClient.Spec.StorageProviderEndpoint, utils.OcsClientTimeout)
 	if err != nil {
 		r.log.Error(err, "failed to create provider client")
@@ -173,6 +179,8 @@ func (r *obcReconcile) handleObcDeletion(
 }
 
 // getStorageClientFromStorageClass returns the StorageClient that owns the given StorageClass (via ownerReference).
+// If the StorageClass exists but has no StorageClient owner reference, it returns (nil, nil) so callers can skip
+// reconcile without treating it as an error.
 func (r *obcReconcile) getStorageClientFromStorageClass(storageClassName string) (*v1alpha1.StorageClient, error) {
 	storageClass := &storagev1.StorageClass{}
 	storageClass.Name = storageClassName
@@ -186,7 +194,7 @@ func (r *obcReconcile) getStorageClientFromStorageClass(storageClassName string)
 		},
 	)
 	if ownerStorageClientIndex == -1 {
-		return nil, fmt.Errorf("StorageClass %q has no StorageClient ownerReference", storageClassName)
+		return nil, nil
 	}
 	storageClient := &v1alpha1.StorageClient{}
 	storageClient.Name = storageClass.OwnerReferences[ownerStorageClientIndex].Name


### PR DESCRIPTION
### Describe the problem
Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)
It fixes the reconcile error that it raised in ocs-client-operator that is running on the provider cluster.
On the provider cluster, we would have the created OBCs for the client clusters, and also OBCs that were created for applications that are running on the provider cluster, and for those cases we do not need the reconcile (to send `Notify` in case of create or delete OBC).

### Explain the changes
1. In the OBC controller - When there is no owner reference on the storage class and finish the reconcile in this case.

### Issues: [DFBUGS-6418](https://redhat.atlassian.net/browse/DFBUGS-6418)

### Testing Instructions:
#### Manual Test:
Requirements:
1. Set up with 2 clusters: Provider with a storage system and a client cluster connected to it (after onboarding).
2. Install the NooBaa OB and OBC CRDs

Steps:
1. Client cluster: create an OBC
2. Provider cluster - check the logs: `oc logs -n openshift-storage ocs-client-operator-controller-manager-<chars> -f`
It was:
```
2026-04-23T10:38:19Z	ERROR	Reconciler error	{"controller": "ObjectBucketClaim", "controllerGroup": "objectbucket.io", "controllerKind": "ObjectBucketClaim", "ObjectBucketClaim": {"name":"remote-obc-626199e412aa11ceb49fb30cae5216f6","namespace":"openshift-storage"}, "namespace": "openshift-storage", "name": "remote-obc-626199e412aa11ceb49fb30cae5216f6", "reconcileID": "fc4977fa-d2dc-4be0-827c-72f90bbd8bda", "error": "failed to get StorageClient: StorageClass \"openshift-storage.noobaa.io\" has no StorageClient ownerReference"}
```
After the change, it is:
```
2026-04-29T15:41:26Z	INFO	OBC	Starting reconcile iteration for OBC	{"controller": "ObjectBucketClaim", "controllerGroup": "objectbucket.io", "controllerKind": "ObjectBucketClaim", "ObjectBucketClaim": {"name":"remote-obc-626199e412aa11ceb49fb30cae5216f6","namespace":"openshift-storage"}, "namespace": "openshift-storage", "name": "remote-obc-626199e412aa11ceb49fb30cae5216f6", "reconcileID": "9b042fb8-a6b6-49f3-8622-3badf62c488f"}
2026-04-29T15:41:26Z	INFO	OBC	StorageClass is not owned by a StorageClient; skipping OBC reconciliation	{"controller": "ObjectBucketClaim", "controllerGroup": "objectbucket.io", "controllerKind": "ObjectBucketClaim", "ObjectBucketClaim": {"name":"remote-obc-626199e412aa11ceb49fb30cae5216f6","namespace":"openshift-storage"}, "namespace": "openshift-storage", "name": "remote-obc-626199e412aa11ceb49fb30cae5216f6", "reconcileID": "9b042fb8-a6b6-49f3-8622-3badf62c488f", "storageClassName": "openshift-storage.noobaa.io"}
```

