### PR TITLE
controllers: use the unspecified as a valid operation

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -957,7 +957,9 @@ func (r *storageClientReconcile) reconcileResourcesByGK(
 
 		desiredState := objectsToReconcile[idx]
 		switch desiredState.operation {
-		case provider.KubeClientOp_CREATE_OR_UPDATE:
+		// TODO (leelavg): using unspecified is temporary to unblock upgrades and when the
+		// actual fix is delivered the testing should be without the unspecified op.
+		case provider.KubeClientOp_CREATE_OR_UPDATE, provider.KubeClientOp_OPERATION_UNSPECIFIED:
 			if err := r.reconcileResource(kubeObject, desiredState.bytes, desiredState.NamespacedName); err != nil {
 				multierr.AppendInto(combinedErr, err)
 			} else {


### PR DESCRIPTION
server & client communication isn't designed to be forward compatible, however with local client the subscription is handled by odf-op and it switches the channel before ocs-op upgrades with a possibility of server working on stale heartbeat data.

this fix is temporary to unblock upgrade builds till the permanent one is merged.