### PR TITLE
controller: mark reconciled objects irrespective of reconcile status

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -942,18 +942,15 @@ func (r *storageClientReconcile) reconcileResourcesByGK(
 		kubeObject := untypedInstance.(client.Object)
 
 		desiredState := objectsToReconcile[idx]
+		reconciledObjects[desiredState.NamespacedName] = true
 		switch desiredState.operation {
 		case provider.KubeClientOp_CREATE_OR_UPDATE:
 			if err := r.reconcileResource(kubeObject, desiredState.bytes, desiredState.NamespacedName); err != nil {
 				multierr.AppendInto(combinedErr, err)
-			} else {
-				reconciledObjects[desiredState.NamespacedName] = true
 			}
 		case provider.KubeClientOp_UPDATE_SUB_RESOURCE:
 			if err := r.reconcileSubResource(kubeObject, desiredState.bytes, desiredState.NamespacedName, desiredState.subResource); err != nil {
 				multierr.AppendInto(combinedErr, err)
-			} else {
-				reconciledObjects[desiredState.NamespacedName] = true
 			}
 		default:
 			r.log.Info(


### PR DESCRIPTION
### Explain the changes:
Add all the kube objects received in `GetDesiredClientState` to list of reocnciled objects maintained on client cluster irrespective of the status of its reconcilation.

Background:
The provider cluster is the source of truth for the client cluster and all the objects received from the provider are required to be created/updated on the client cluster. This fixes issue of resources being deleted when the client if not aware of what operation to perform for the object.

**Issue fixed**
[ocs-operator csv upgrade failed from 4.21 to 4.22](https://redhat.atlassian.net/browse/DFBUGS-6475)