### PR TITLE
Fix - Add Watch for OBC in Storageclient Controller In Case Status is Manually Deleted

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -285,6 +285,7 @@ func main() {
 		Scheme:            mgr.GetScheme(),
 		OperatorNamespace: utils.GetOperatorNamespace(),
 		OperatorPodName:   podName,
+		AvailableCrds:     availCrds,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "StorageClient")
 		os.Exit(1)

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -67,6 +67,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -137,6 +138,7 @@ type StorageClientReconciler struct {
 	Scheme            *runtime.Scheme
 	OperatorNamespace string
 	OperatorPodName   string
+	AvailableCrds     map[string]bool
 
 	cache            cache.Cache
 	controller       controller.Controller
@@ -212,7 +214,33 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return requests
 		},
 	)
-	controller, err := ctrl.NewControllerManagedBy(mgr).
+	obcStatusChangedPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldOBC, oldOk := e.ObjectOld.(*nbv1.ObjectBucketClaim)
+			newOBC, newOk := e.ObjectNew.(*nbv1.ObjectBucketClaim)
+			if !oldOk || !newOk || oldOBC == nil || newOBC == nil {
+				return false
+			}
+			return !reflect.DeepEqual(oldOBC.Status, newOBC.Status)
+		},
+	}
+	enqueueStorageClientRequestFromOBC := handler.EnqueueRequestsFromMapFunc(
+		func(_ context.Context, obj client.Object) []ctrl.Request {
+			if obj == nil {
+				return nil
+			}
+			labels := obj.GetLabels()
+			if labels == nil {
+				return nil
+			}
+			storageClientName := labels[storageClientNameLabel]
+			if storageClientName == "" {
+				return nil
+			}
+			return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: storageClientName}}}
+		},
+	)
+	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.StorageClient{}).
 		Owns(&batchv1.CronJob{}).
 		Owns(&quotav1.ClusterResourceQuota{}, builder.WithPredicates(generationChangePredicate)).
@@ -235,8 +263,21 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				utils.EventTypePredicate(true, false, false, false),
 			),
 			builder.OnlyMetadata,
-		).
-		Build(r)
+		)
+	if r.AvailableCrds[ObjectBucketClaimCrdName] {
+		bldr = bldr.Watches(
+			&nbv1.ObjectBucketClaim{},
+			enqueueStorageClientRequestFromOBC,
+			builder.WithPredicates(
+				predicate.And(
+					utils.EventTypePredicate(false, true, false, false),
+					utils.LabelExistsPredicate(storageClientNameLabel),
+					obcStatusChangedPredicate,
+				),
+			),
+		)
+	}
+	controller, err := bldr.Build(r)
 
 	r.controller = controller
 	r.cache = mgr.GetCache()

--- a/pkg/utils/predicates.go
+++ b/pkg/utils/predicates.go
@@ -34,3 +34,14 @@ func EventTypePredicate(create, update, del, generic bool) predicate.Predicate {
 		},
 	}
 }
+
+// LabelExistsPredicate return a predicate the filter events based on the existence of a label
+func LabelExistsPredicate(labelKey string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if obj == nil || obj.GetLabels() == nil {
+			return false
+		}
+		_, found := obj.GetLabels()[labelKey]
+		return found
+	})
+}

--- a/pkg/utils/predicates_test.go
+++ b/pkg/utils/predicates_test.go
@@ -1,0 +1,202 @@
+package utils
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestLabelExistsPredicate(t *testing.T) {
+	const labelKey = "ocs.openshift.io/storageclient.name"
+
+	tests := []struct {
+		name     string
+		obj      *corev1.ConfigMap
+		expected bool // true if any event path should allow; we assert Create matches filter(obj)
+	}{
+		{
+			name: "label present non-empty value",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{labelKey: "client-a"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "label present empty value",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{labelKey: ""},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "label key absent",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"other": "x"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "labels map nil",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: false,
+		},
+		{
+			name: "labels map empty",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_Create", func(t *testing.T) {
+			p := LabelExistsPredicate(labelKey)
+			got := p.Create(event.CreateEvent{Object: tt.obj})
+			if got != tt.expected {
+				t.Fatalf("Create = %v, expect %v", got, tt.expected)
+			}
+		})
+		t.Run(tt.name+"_Delete", func(t *testing.T) {
+			p := LabelExistsPredicate(labelKey)
+			got := p.Delete(event.DeleteEvent{Object: tt.obj})
+			if got != tt.expected {
+				t.Fatalf("Delete = %v, expect %v", got, tt.expected)
+			}
+		})
+		t.Run(tt.name+"_Generic", func(t *testing.T) {
+			p := LabelExistsPredicate(labelKey)
+			got := p.Generic(event.GenericEvent{Object: tt.obj})
+			if got != tt.expected {
+				t.Fatalf("Generic = %v, expect %v", got, tt.expected)
+			}
+		})
+		t.Run(tt.name+"_Update", func(t *testing.T) {
+			p := LabelExistsPredicate(labelKey)
+			// NewPredicateFuncs only inspects ObjectNew on Update.
+			old := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+			}
+			got := p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: tt.obj})
+			if got != tt.expected {
+				t.Fatalf("Update = %v, expect %v", got, tt.expected)
+			}
+		})
+	}
+
+	t.Run("Create nil object", func(t *testing.T) {
+		p := LabelExistsPredicate(labelKey)
+		if p.Create(event.CreateEvent{Object: nil}) {
+			t.Fatal("Create with nil object should be false")
+		}
+	})
+
+	t.Run("Update uses ObjectNew only not ObjectOld", func(t *testing.T) {
+		p := LabelExistsPredicate(labelKey)
+		cases := []struct {
+			name     string
+			old      *corev1.ConfigMap
+			newObj   *corev1.ConfigMap
+			expected bool
+		}{
+			{
+				name: "old has label new does not",
+				old: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{labelKey: "client-a"},
+					},
+				},
+				newObj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"other": "x"},
+					},
+				},
+				expected: false,
+			},
+			{
+				name: "old lacks label new has label",
+				old: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"other": "x"},
+					},
+				},
+				newObj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{labelKey: "client-a"},
+					},
+				},
+				expected: true,
+			},
+			{
+				name: "both have label value may change",
+				old: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{labelKey: "client-a"},
+					},
+				},
+				newObj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{labelKey: "client-b"},
+					},
+				},
+				expected: true,
+			},
+			{
+				name: "neither has label key",
+				old: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"other": "1"},
+					},
+				},
+				newObj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"other": "2"},
+					},
+				},
+				expected: false,
+			},
+			{
+				name: "old nil labels new has label",
+				old: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+				},
+				newObj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{labelKey: "client-a"},
+					},
+				},
+				expected: true,
+			},
+			{
+				name: "old has label new nil labels",
+				old: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{labelKey: "client-a"},
+					},
+				},
+				newObj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+				},
+				expected: false,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := p.Update(event.UpdateEvent{ObjectOld: tc.old, ObjectNew: tc.newObj})
+				if got != tc.expected {
+					t.Fatalf("Update = %v, expect %v", got, tc.expected)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
### Describe the problem
Part of [RHSTOR-6230](https://issues.redhat.com/browse/RHSTOR-6230)

### Explain the changes
1. In main - add the map of `AvailableCrds` to `StorageClientReconciler`.
2. Add a watch on OBC in case (AND): (1) update event, (2) has storage client label value name, (3) status change
3. Added utility function `LabelExistsPredicate`
4. Added AI-generated tests for the utility function `LabelExistsPredicate`.

### Testing Instructions:
#### Unit tests:
Please run: `go test ./pkg/utils/ -v -run TestLabelExistsPredicate`

#### Manual Test:
Currently, we see that the storage client controller is triggered every minute, so we cannot reproduce the situation where the OBC status was deleted (because now it is always getting updated back, so effectively we don't see the new watch changes). So now I just verify that the pod does not panic when there is an OBC CRD installed and when there is not.