### PR TITLE
metrics: remove redundant value check

### DIFF
--- a/internal/controller/alert/collector.go
+++ b/internal/controller/alert/collector.go
@@ -61,12 +61,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				labelNames, nil,
 			)
 
-			value := alert.Value
-			if value == 0 {
-				value = 1
-			}
-
-			m, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, value, labelValues...)
+			m, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, alert.Value, labelValues...)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
The value will only be 0 in cases when the alert is not firing. In this case it is a redundant check as
`GetClientAlerts` RPC only returns firing alerts.