### PR TITLE
bundle: add missing Prometheus RBAC Role

### DIFF
--- a/bundle/manifests/ocs-client-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/ocs-client-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ocs-client-operator-prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/ocs-client-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/ocs-client-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ocs-client-operator-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocs-client-operator-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -24,3 +24,5 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
+- prometheus_role.yaml
+- prometheus_role_binding.yaml

--- a/config/rbac/prometheus_role.yaml
+++ b/config/rbac/prometheus_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/prometheus_role_binding.yaml
+++ b/config/rbac/prometheus_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring


### PR DESCRIPTION
## Problem

Client-side alerts were not firing on OCS client clusters. The root cause was missing RBAC that prevented Prometheus from discovering and scraping metrics targets in the ocs-client-operator namespace.

## What This PR Does

Adds a namespaced `Role` and `RoleBinding` for the OpenShift Monitoring Prometheus service account so it can discover and scrape metrics endpoints on client clusters.

**Role** (`ocs-client-operator-prometheus-k8s`):
- Grants `get`, `list`, `watch` on `endpoints`, `pods`, and `services` in the ocs-client-operator namespace

**RoleBinding** (`ocs-client-operator-prometheus-k8s`):
- Binds the above Role to the `prometheus-k8s` ServiceAccount in the `openshift-monitoring` namespace