### PR TITLE
[release-4.16] Bump go (stdlib: net/http) from 1.21 to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.21
+go 1.21.9
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `go.mod`)
