### PR TITLE
[release-4.19] Bump go (stdlib) from 1.23.0 to 1.23.1

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.23.0
+go 1.23.1
 
 require k8s.io/apimachinery v0.31.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.23.0
+go 1.23.1
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -260,7 +260,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.22.5
 github.com/ramendr/ramen/api/v1alpha1
 # github.com/red-hat-storage/ocs-client-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.23.0
+## explicit; go 1.23.1
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20251125054258-7bbeff93d115
 ## explicit; go 1.23.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `api/go.mod`)
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `go.mod`)
