### PR TITLE
[release-4.20] Bump go (stdlib) from 1.23.0 to 1.23.1

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.23.0
+go 1.23.1
 
 require k8s.io/apimachinery v0.31.0
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -255,7 +255,7 @@ github.com/ramendr/ramen/api/v1alpha1
 ## explicit; go 1.22.0
 github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1
 # github.com/red-hat-storage/ocs-client-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.23.0
+## explicit; go 1.23.1
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20251009102644-5727239a7b48
 ## explicit; go 1.24.3


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `api/go.mod`)
