### PR TITLE
controllers: automate RBD snapshot metadata sidecar setup (KEP-3314/CBT)

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -51,6 +51,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/version"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
@@ -176,7 +177,7 @@ func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false
 				}
 
-				if obj.GetName() == operatorConfigMapName {
+				if obj.GetName() == operatorConfigMapName || obj.GetName() == utils.OpenShiftServiceCAConfigMapName {
 					return true
 				}
 
@@ -699,9 +700,16 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 				rbdDriver.Spec.ControllerPlugin = &csiopv1.ControllerPluginSpec{}
 			}
 			rbdDriver.Spec.ControllerPlugin.HostNetwork = ptr.To(useHostNetForRbdCtrlPlugin)
+			templates.InjectSnapshotMetadataTLSVolume(rbdDriver.Spec.ControllerPlugin)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile rbd driver: %v", err)
+		}
+		if err := c.reconcileRbdSMSService(); err != nil {
+			return fmt.Errorf("failed to reconcile snapshot metadata service: %w", err)
+		}
+		if err := c.reconcileRbdSMSSpecConfigMap(); err != nil {
+			return fmt.Errorf("failed to reconcile snapshot metadata spec ConfigMap: %w", err)
 		}
 	}
 
@@ -1158,7 +1166,7 @@ func (c *OperatorConfigMapReconciler) reconcileWebhookService() error {
 		if err := c.own(svc); err != nil {
 			return err
 		}
-		utils.AddAnnotation(svc, "service.beta.openshift.io/serving-cert-secret-name", "ocs-client-webhook-cert-secret")
+		utils.AddAnnotation(svc, utils.ServingCertSecretAnnotation, "ocs-client-webhook-cert-secret")
 		templates.WebhookService.Spec.DeepCopyInto(&svc.Spec)
 		return nil
 	})
@@ -1350,4 +1358,62 @@ func (c *OperatorConfigMapReconciler) hasVolumeSnapshotContentsWithNfsDriver() (
 		return false, fmt.Errorf("failed to list NFS driver VolumeSnapshotContents: %v", err)
 	}
 	return len(vscList.Items) != 0, nil
+}
+
+func (c *OperatorConfigMapReconciler) reconcileRbdSMSService() error {
+	svc := &corev1.Service{}
+	svc.Name = templates.SnapshotMetadataServiceName
+	svc.Namespace = c.OperatorNamespace
+	if err := c.createOrUpdate(svc, func() error {
+		if err := c.own(svc); err != nil {
+			return err
+		}
+		utils.AddAnnotation(svc, utils.ServingCertSecretAnnotation, templates.SnapshotMetadataTLSSecretName)
+		svc.Spec.Ports = []corev1.ServicePort{{
+			Port:       templates.SnapshotMetadataServicePort,
+			TargetPort: intstr.FromInt32(templates.SnapshotMetadataGRPCPort),
+		}}
+		svc.Spec.Selector = map[string]string{"app": templates.RBDDriverName + "-ctrlplugin"}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile snapshot metadata service: %w", err)
+	}
+	return nil
+}
+
+func (c *OperatorConfigMapReconciler) reconcileRbdSMSSpecConfigMap() error {
+	// openshift-service-ca.crt is auto-created per namespace by OpenShift service-CA operator
+	caCM := &corev1.ConfigMap{}
+	caCM.Name = utils.OpenShiftServiceCAConfigMapName
+	caCM.Namespace = c.OperatorNamespace
+	if err := c.get(caCM); err != nil {
+		return fmt.Errorf("failed to get ConfigMap %s/%s: %w", c.OperatorNamespace, utils.OpenShiftServiceCAConfigMapName, err)
+	}
+	caCert := caCM.Data[utils.ServiceCACertKey]
+	if caCert == "" {
+		c.log.Info("service CA cert not yet available, waiting for requeue", "configMap", utils.OpenShiftServiceCAConfigMapName)
+		return nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	cm.Name = templates.SnapshotMetadataConfigName
+	cm.Namespace = c.OperatorNamespace
+	if err := c.createOrUpdate(cm, func() error {
+		if err := c.own(cm); err != nil {
+			return err
+		}
+		cm.Data = map[string]string{
+			"address": fmt.Sprintf("%s.%s.svc:%d",
+				templates.SnapshotMetadataServiceName,
+				c.OperatorNamespace,
+				templates.SnapshotMetadataServicePort),
+			"audience":   templates.RBDDriverName,
+			"caCert":     caCert,
+			"driverName": templates.RBDDriverName,
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile snapshot metadata spec ConfigMap: %w", err)
+	}
+	return nil
 }

--- a/internal/controller/operatorconfigmap_controller_test.go
+++ b/internal/controller/operatorconfigmap_controller_test.go
@@ -1,21 +1,26 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"testing"
 
 	"github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
 	"github.com/red-hat-storage/ocs-client-operator/pkg/console"
+	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
 	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 
 	configv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -61,6 +66,18 @@ func newFakeScheme(t *testing.T) *runtime.Scheme {
 	assert.Nil(t, err, "failed to add v1alpha1 scheme")
 
 	return scheme
+}
+
+// newSMSReconciler builds a reconciler wired with a fake client and the ownerRef ConfigMap set.
+func newSMSReconciler(t *testing.T, objs ...client.Object) OperatorConfigMapReconciler {
+	r := newFakeConfigMapReconciler(t)
+	ownerCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner-cm", Namespace: testNamespace, UID: "test-uid"}}
+	allObjs := append([]client.Object{ownerCM}, objs...)
+	r.Client = newFakeClientBuilder(r.Scheme).WithObjects(allObjs...).Build()
+	r.ctx = context.Background()
+	r.operatorConfigMap = ownerCM
+	r.AvailableCrds = map[string]bool{}
+	return r
 }
 
 func newFakeConfigMapReconciler(t *testing.T) OperatorConfigMapReconciler {
@@ -466,4 +483,52 @@ func TestBuildDesiredNginxDataWithProxies(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileSMSService(t *testing.T) {
+	r := newSMSReconciler(t)
+	err := r.reconcileRbdSMSService()
+	assert.NoError(t, err)
+
+	svc := &corev1.Service{}
+	err = r.Get(r.ctx, types.NamespacedName{Name: templates.SnapshotMetadataServiceName, Namespace: testNamespace}, svc)
+	assert.NoError(t, err)
+	assert.Equal(t, templates.SnapshotMetadataServicePort, svc.Spec.Ports[0].Port)
+	assert.Equal(t, templates.SnapshotMetadataTLSSecretName, svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"])
+}
+
+func TestReconcileSMSSpecConfigMap_CANotYetInjected(t *testing.T) {
+	caCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "openshift-service-ca.crt", Namespace: testNamespace},
+	}
+	r := newSMSReconciler(t, caCM)
+	err := r.reconcileRbdSMSSpecConfigMap()
+	assert.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	err = r.Get(r.ctx, types.NamespacedName{Name: templates.SnapshotMetadataConfigName, Namespace: testNamespace}, cm)
+	assert.True(t, kerrors.IsNotFound(err), "spec ConfigMap should not be created when CA not yet injected")
+}
+
+func TestReconcileSMSSpecConfigMap(t *testing.T) {
+	caCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "openshift-service-ca.crt", Namespace: testNamespace},
+		Data:       map[string]string{"service-ca.crt": "fake-ca-cert"},
+	}
+	r := newSMSReconciler(t, caCM)
+	err := r.reconcileRbdSMSSpecConfigMap()
+	assert.NoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	err = r.Get(r.ctx, types.NamespacedName{Name: templates.SnapshotMetadataConfigName, Namespace: testNamespace}, cm)
+	assert.NoError(t, err)
+	assert.Equal(t, "fake-ca-cert", cm.Data["caCert"])
+	assert.Equal(t, templates.RBDDriverName, cm.Data["audience"])
+	assert.Contains(t, cm.Data["address"], templates.SnapshotMetadataServiceName)
+}
+
+func TestDeleteDelegatedCSI(t *testing.T) {
+	r := newSMSReconciler(t)
+	err := r.deleteDelegatedCSI()
+	assert.NoError(t, err)
 }

--- a/pkg/templates/csi.go
+++ b/pkg/templates/csi.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"slices"
 
 	csiopv1 "github.com/ceph/ceph-csi-operator/api/v1"
 	secv1 "github.com/openshift/api/security/v1"
@@ -14,6 +15,38 @@ import (
 const RBDDriverName = "openshift-storage.rbd.csi.ceph.com"
 const CephFsDriverName = "openshift-storage.cephfs.csi.ceph.com"
 const NfsDriverName = "openshift-storage.nfs.csi.ceph.com"
+
+// Snapshot metadata sidecar automation (KEP-3314 / CBT)
+const SnapshotMetadataServiceName = "openshift-storage-rbd-snapshot-metadata"
+const SnapshotMetadataTLSSecretName = "openshift-storage-rbd-snapshot-metadata-tls"
+const SnapshotMetadataConfigName = RBDDriverName // must match driver name
+const SnapshotMetadataGRPCPort = int32(50051)
+const SnapshotMetadataServicePort = int32(6443)
+const snapshotMetadataTLSKeyVolumeName = "tls-key"
+
+func InjectSnapshotMetadataTLSVolume(cp *csiopv1.ControllerPluginSpec) {
+	vol := csiopv1.VolumeSpec{
+		Volume: corev1.Volume{
+			Name: snapshotMetadataTLSKeyVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: SnapshotMetadataTLSSecretName},
+			},
+		},
+		Mount: corev1.VolumeMount{
+			Name:      snapshotMetadataTLSKeyVolumeName,
+			MountPath: "/tmp/certificates",
+			ReadOnly:  true,
+		},
+	}
+	idx := slices.IndexFunc(cp.Volumes, func(v csiopv1.VolumeSpec) bool {
+		return v.Volume.Name == snapshotMetadataTLSKeyVolumeName
+	})
+	if idx == -1 {
+		cp.Volumes = append(cp.Volumes, vol)
+	} else {
+		cp.Volumes[idx] = vol
+	}
+}
 
 // security context constraints
 const SCCName = "ceph-csi-op-scc"

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -72,6 +72,10 @@ const (
 
 	MetricsServiceNameEnvVar = "METRICS_SERVICE_NAME"
 	MetricsPortEnvVar        = "METRICS_PORT"
+
+	OpenShiftServiceCAConfigMapName = "openshift-service-ca.crt"
+	ServiceCACertKey                = "service-ca.crt"
+	ServingCertSecretAnnotation     = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
 // GetOperatorNamespace returns the namespace where the operator is deployed.

--- a/service/status-report/main.go
+++ b/service/status-report/main.go
@@ -183,14 +183,14 @@ const (
 
 func getCABundle(ctx context.Context, cl client.Client, namespace string) ([]byte, error) {
 	configMap := &corev1.ConfigMap{}
-	configMap.Name = "openshift-service-ca.crt"
+	configMap.Name = utils.OpenShiftServiceCAConfigMapName
 	configMap.Namespace = namespace
 
 	if err := cl.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
 		return nil, fmt.Errorf("failed to get CA bundle ConfigMap: %v", err)
 	}
 
-	caBundle, ok := configMap.Data["service-ca.crt"]
+	caBundle, ok := configMap.Data[utils.ServiceCACertKey]
 	if !ok {
 		return nil, fmt.Errorf("service-ca.crt key not found in ConfigMap")
 	}


### PR DESCRIPTION
## Summary

Automates deployment of the `external-snapshot-metadata` gRPC sidecar for CSI Changed Block Tracking (CBT, KEP-3314) when the RBD driver is enabled.

### Resources created (when `enableRbdDriver=true`)

- **Service** `openshift-storage-rbd-snapshot-metadata` — port 6443→50051, annotated with `serving-cert-secret-name` so OpenShift service-CA auto-provisions TLS
- **Spec ConfigMap** `openshift-storage.rbd.csi.ceph.com` (= driver name) — keys: `address`, `audience`, `caCert`, `driverName`. Source of truth for backup vendors (Velero/OADP, Kasten)
- **tls-key VolumeSpec** upserted into RBD Driver CR's `controllerPlugin.volumes` — ceph-csi-operator detects this volume and deploys the `csi-snapshot-metadata` sidecar container

### Design decisions

- **No SMS CR creation** — `SnapshotMetadataService` CR (`cbt.storage.k8s.io/v1beta1`) is admin responsibility when the CRD is installed. The ConfigMap holds all the same fields and serves as source of truth
- **No `external-snapshot-metadata` vendor dependency** — no SMS types needed since we don't create the CR
- **CA cert** read from pre-existing `openshift-service-ca.crt` ConfigMap (same as `status-report` service). ConfigMap watch triggers re-reconcile when OpenShift injects the CA
- **Shared constants** extracted to `pkg/utils`: `ServingCertSecretAnnotation`, `OpenShiftServiceCAConfigMapName`, `ServiceCACertKey`
- Service and ConfigMap owned by operator ConfigMap → auto-GC on deletion

### Dependencies

Requires ceph-csi-operator build with tls-key volume trigger (instead of SMS CR check) — already merged to upstream main.

### Files changed

| File | Change |
|------|--------|
| `internal/controller/operatorconfigmap_controller.go` | `reconcileSMSService()`, `reconcileSMSSpecConfigMap()`, tls-key volume injection, `openshift-service-ca.crt` watch |
| `internal/controller/operatorconfigmap_controller_test.go` | 4 unit tests: Service, Spec ConfigMap (CA empty + populated), deletion |
| `pkg/templates/csi.go` | Constants + `InjectSnapshotMetadataTLSVolume()` helper |
| `pkg/utils/k8sutils.go` | `ServingCertSecretAnnotation`, `OpenShiftServiceCAConfigMapName`, `ServiceCACertKey` |
| `service/status-report/main.go` | Use shared constants instead of hardcoded strings |

## Test plan

- [x] `make test` passes
- [x] RBD enabled → Service, Spec ConfigMap, tls-key volume created
- [x] ceph-csi-operator deploys `csi-snapshot-metadata` sidecar container with `--audience` flag
- [x] Service selector matches RBD controller plugin pods
- [x] TLS Secret auto-generated by OpenShift service-CA
- [x] Spec ConfigMap has correct address, audience, caCert
- [x] No SnapshotMetadataService CR created by operator
- [x] Operator ConfigMap deletion → Service and ConfigMap GC'd via ownerRef
- [x] End-to-end gRPC API test — `snapshot-metadata-lister` returns block metadata
- [x] SMS-CR-free operation verified (with upstream sidecar audience fix)

<details>
<summary><strong>Live cluster verification outputs</strong></summary>

### Service
```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    service.beta.openshift.io/serving-cert-secret-name: openshift-storage-rbd-snapshot-metadata-tls
    service.beta.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@...
  name: openshift-storage-rbd-snapshot-metadata
  namespace: openshift-storage
  ownerReferences:
  - apiVersion: v1
    controller: true
    kind: ConfigMap
    name: ocs-client-operator-config
spec:
  ports:
  - port: 6443
    targetPort: 50051
  selector:
    app: openshift-storage.rbd.csi.ceph.com-ctrlplugin
  type: ClusterIP
```

### TLS Secret (auto-generated by OpenShift service-CA)
```
type: kubernetes.io/tls
annotations:
  service.beta.openshift.io/expiry: "2028-06-29T10:13:14Z"
  service.beta.openshift.io/originating-service-name: openshift-storage-rbd-snapshot-metadata
```

### Spec ConfigMap
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: openshift-storage.rbd.csi.ceph.com
  ownerReferences:
  - controller: true
    kind: ConfigMap
    name: ocs-client-operator-config
data:
  address: openshift-storage-rbd-snapshot-metadata.openshift-storage.svc:6443
  audience: openshift-storage.rbd.csi.ceph.com
  caCert: |
    -----BEGIN CERTIFICATE-----
    MIICAjCCAYigAwIBAgIIA/OFarVPeGgw...
    -----END CERTIFICATE-----
  driverName: openshift-storage.rbd.csi.ceph.com
```

### Driver CR tls-key Volume
```yaml
spec:
  controllerPlugin:
    volumes:
    - mount:
        mountPath: /tmp/certificates
        name: tls-key
        readOnly: true
      volume:
        name: tls-key
        secret:
          secretName: openshift-storage-rbd-snapshot-metadata-tls
```

### Sidecar container args
```json
["--v=5", "--timeout=150s", "--port=50051",
 "--csi-address=unix:///csi/csi.sock",
 "--tls-cert=/tmp/certificates/tls.crt",
 "--tls-key=/tmp/certificates/tls.key",
 "--audience=openshift-storage.rbd.csi.ceph.com"]
```

### Sidecar containers in RBD ctrlplugin pod
```
csi-rbdplugin csi-provisioner csi-resizer csi-attacher csi-snapshotter
csi-addons csi-omap-generator log-rotator csi-snapshot-metadata
```

### End-to-end gRPC API test
```
$ snapshot-metadata-lister -snapshot cbt-test-snap -namespace openshift-storage -address "openshift-storage-rbd-snapshot-metadata.openshift-storage.svc:6443" -audience "openshift-storage.rbd.csi.ceph.com" -ca-cert-file /tmp/ca.crt

Record#   VolCapBytes  BlockMetadataType   ByteOffset     SizeBytes
------- -------------- ----------------- -------------- --------------
      1     1073741824   VARIABLE_LENGTH              0        4194304
```

### Sidecar logs (successful request)
```
sidecar.go:93] CSI driver name: "openshift-storage.rbd.csi.ceph.com"
sidecar.go:319] GRPC server started listening on port 50051
get_metadata_allocated.go:69] "calling CSI driver" op="GetMetadataAllocated-1"
  snapshotId="0001-0011-openshift-storage-...-aeaa284d-..."
get_metadata_allocated.go:193] "stream response" volumeCapacityBytes=1073741824
  blockMetadata="[{0,4194304}]" numBlockMetadata=1
get_metadata_allocated.go:154] "stream EOF" lastResponseNum=1
```

### No SMS CR
```
$ oc get snapshotmetadataservices
No resources found
```

</details>

<details>
<summary><strong>Upstream dependencies</strong></summary>

| Repo | PR/Issue | What | Status |
|------|----------|------|--------|
| ceph-csi-operator | [#519](https://github.com/ceph/ceph-csi-operator/pull/519) | tls-key volume trigger + `--audience` sidecar arg | merged |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)