### PR TITLE
controllers: Update pods to have annotations with openshift.io/required-scc

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -438,6 +438,7 @@ spec:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
+                openshift.io/required-scc: restricted-v2
               labels:
                 app: ocs-client-operator
                 control-plane: controller-manager
@@ -512,6 +513,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                openshift.io/required-scc: restricted-v2
               labels:
                 app.kubernetes.io/name: ocs-client-operator-console
             spec:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -9,6 +9,8 @@ spec:
       app.kubernetes.io/name: ocs-client-operator-console
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         app.kubernetes.io/name: ocs-client-operator-console
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -850,6 +850,9 @@ func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersio
 					ActiveDeadlineSeconds:   &jobDeadLineSeconds,
 					TTLSecondsAfterFinished: &keepJobResourceSeconds,
 					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: templates.RestrictedSCCPodAnnotations,
+						},
 						Spec: corev1.PodSpec{
 							ActiveDeadlineSeconds: &podDeadLineSeconds,
 							Containers: []corev1.Container{

--- a/pkg/templates/csi.go
+++ b/pkg/templates/csi.go
@@ -49,7 +49,19 @@ func InjectSnapshotMetadataTLSVolume(cp *csiopv1.ControllerPluginSpec) {
 }
 
 // security context constraints
-const SCCName = "ceph-csi-op-scc"
+const (
+	SCCName           = "ceph-csi-op-scc"
+	restrictedSCCName = "restricted-v2"
+)
+
+var (
+	csiSCCPodAnnotations = map[string]string{
+		secv1.RequiredSCCAnnotation: SCCName,
+	}
+	RestrictedSCCPodAnnotations = map[string]string{
+		secv1.RequiredSCCAnnotation: restrictedSCCName,
+	}
+)
 
 // TODO: could pull directly from ceph-csi-operator when available
 var securityContextConstraints = secv1.SecurityContextConstraints{
@@ -212,6 +224,7 @@ var CSIOperatorConfigSpec = csiopv1.OperatorConfigSpec{
 				},
 			},
 			PodCommonSpec: csiopv1.PodCommonSpec{
+				Annotations:        csiSCCPodAnnotations,
 				PrioritylClassName: ptr.To("system-cluster-critical"),
 				ImagePullPolicy:    corev1.PullIfNotPresent,
 				Tolerations: []corev1.Toleration{
@@ -271,6 +284,7 @@ var CSIOperatorConfigSpec = csiopv1.OperatorConfigSpec{
 			},
 			KubeletDirPath: "/var/lib/kubelet",
 			PodCommonSpec: csiopv1.PodCommonSpec{
+				Annotations:        csiSCCPodAnnotations,
 				PrioritylClassName: ptr.To("system-node-critical"),
 				ImagePullPolicy:    corev1.PullIfNotPresent,
 				Tolerations: []corev1.Toleration{


### PR DESCRIPTION
Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) [Enforce least-privileged Security Context Constraint (SCC) across ODF pods ](https://redhat.atlassian.net/browse/RHSTOR-8757)

Pins every Pod managed by ocs-client-operator to an explicit Security Context Constraint using the `openshift.io/required-scc` annotation, replacing reliance on OpenShift SCC admission to dynamically select the most permissive matching SCC.

- Add shared SCC annotation helpers in `[pkg/templates/csi.go](pkg/templates/csi.go)`: CSI driver pods use `ceph-csi-op-scc`; standard workloads use `restricted-v2`
- Annotate CSI controller and node plugin defaults in `ceph-csi-operator-config` (`OperatorConfig`) so delegated RBD/CephFS/NFS plugin Pods are bound to the existing custom SCC
- Annotate static OLM bundle Deployments: operator manager (`[config/manager/manager.yaml](config/manager/manager.yaml)`) and console plugin (`[config/console/console_init.yaml](config/console/console_init.yaml)`) with `restricted-v2`
- Annotate the per-`StorageClient` status-reporter CronJob pod template in `[internal/controller/storageclient_controller.go](internal/controller/storageclient_controller.go)` with `restricted-v2`

This improves auditability and least-privilege enforcement for regulated deployments by making SCC assignment deterministic and reproducible.

## SCC mapping

| Workload | SCC |
|----------|-----|
| Operator controller-manager | `restricted-v2` |
| ODF client console | `restricted-v2` |
| StorageClient status-reporter CronJob | `restricted-v2` |
| CSI controller + node plugins (via ceph-csi-operator) | `ceph-csi-op-scc` |

## Notes

- The custom CSI SCC (`ceph-csi-op-scc`) and its service-account bindings are already reconciled by this operator; this change only adds the required-SCC pin on the pod templates.
- CSI CNI network annotations merged at reconcile time continue to be additive on top of the SCC annotation.
- Updating pod-template annotations will cause affected Pods to be recreated on rollout.

## Test plan

- [ ] Deploy on an OpenShift cluster with at least one `StorageClient`
- [ ] Verify operator manager pod template and running pod:
  

```bash
  oc -n openshift-storage get deploy ocs-client-operator-controller-manager \
    -o jsonpath='{.spec.template.metadata.annotations.openshift\.io/required-scc}{"\n"}'
  oc -n openshift-storage get pods -l app=ocs-client-operator \
    -o custom-columns=NAME:.metadata.name,SCC:.metadata.annotations.openshift\.io/scc