### PR TITLE
add Renovate bot configuration for automated dependency updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,40 @@
+---
+name: Renovate
+
+on:
+  schedule:
+    # Run before 5am Tuesday UTC
+    - cron: '0 4 * * 2'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46.1.17
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_REPOSITORY_CACHE: 'enabled'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "description": "Renovate configuration for ocs-client-operator",
+  "enabledManagers": ["gomod", "github-actions"],
+  "dependencyDashboard": true,
+  "dependencyDashboardApproval": true,
+  "prConcurrentLimit": 5,
+  "branchConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "timezone": "UTC",
+  "schedule": ["before 5am on tuesday"],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "constraints": {
+    "go": "1.26.1"
+  },
+  "packageRules": [
+    {
+      "description": "Group Go minor and patch updates together",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "Go dependencies (non-major)"
+    },
+    {
+      "description": "Group Go major updates separately, require approval",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Go dependencies (major)",
+      "dependencyDashboardApproval": true,
+      "addLabels": ["go-major-update"]
+    },
+    {
+      "description": "Disable indirect Go dependencies (let go mod tidy handle them)",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
+      "description": "GitHub Actions updates with 7-day stability period and SHA pinning",
+      "matchManagers": ["github-actions"],
+      "stabilityDays": 7,
+      "pinDigests": true,
+      "groupName": "GitHub Actions",
+      "commitMessageTopic": "{{depName}}",
+      "addLabels": ["github-actions"]
+    }
+  ],
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "chore(deps):",
+  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
+  "automerge": false,
+  "platformAutomerge": false
+}


### PR DESCRIPTION
- configure self-hosted Renovate as GitHub Action
- group Go dependencies by update type (major vs non-major)
- disable indirect Go dependencies (handled by go mod tidy)
- enable GitHub Actions updates with 7-day stability period
- require manual approval via dependency dashboard
- schedule updates for Tuesday mornings before 5am UTC