### PR TITLE
bundle: remove operator-config from bundle for olm v1

### DIFF
--- a/bundle/manifests/ocs-client-operator-config_v1_configmap.yaml
+++ b/bundle/manifests/ocs-client-operator-config_v1_configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  generateRbdOMapInfo: "true"
-  topologyFailureDomainLabels: ""
-kind: ConfigMap
-metadata:
-  name: ocs-client-operator-config

--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2026-06-30T07:56:18Z"
+    createdAt: "2026-07-16T07:19:38Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,10 +9,6 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-- literals:
-  - generateRbdOMapInfo=true
-  - topologyFailureDomainLabels=""
-  name: config
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
in v0 we were using this configmap for tweaking operator knobs but v1 doesn't allow resources deployed by bundle to be reconciled by us and the plan is to remove the config from the bundle eventually, this commit is to try out the flow early.

next step would be removing csv as owner of configmap and then remove the configmap from the bundle itself during v1 migration.