### PR TITLE
csi: adjust CSI pods CPU requests on IBM Z

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"net/url"
 	"reflect"
+	goruntime "runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -114,6 +115,9 @@ const (
 
 	pvDriverIndexName  = "index:persistentVolumeDriver"
 	vscDriverIndexName = "index:volumeSnapshotContentDriver"
+
+	ibmZCpuArch         = "s390x"
+	ibmZCpuAdjustFactor = 0.5
 )
 
 // ConfigMapData value from the provider that contains the s3 endpoint info (key is the unique identifier, using which the endpoint is exposed).
@@ -633,6 +637,10 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 		}
 		templates.CSIOperatorConfigSpec.DeepCopyInto(&csiOperatorConfig.Spec)
 		driverSpecDefaults := csiOperatorConfig.Spec.DriverSpecDefaults
+		if goruntime.GOARCH == ibmZCpuArch {
+			adjustPluginCpuResourcesForIbmZ(&driverSpecDefaults.ControllerPlugin.Resources, ibmZCpuAdjustFactor)
+			adjustPluginCpuResourcesForIbmZ(&driverSpecDefaults.NodePlugin.Resources, ibmZCpuAdjustFactor)
+		}
 		if isTnfCluster {
 			templates.CSIOperatorTNFControllerPluginResourceSpec.DeepCopyInto(&driverSpecDefaults.ControllerPlugin.Resources)
 			templates.CSIOperatorTNFNodePluginResourceSpec.DeepCopyInto(&driverSpecDefaults.NodePlugin.Resources)
@@ -1416,4 +1424,34 @@ func (c *OperatorConfigMapReconciler) reconcileRbdSMSSpecConfigMap() error {
 		return fmt.Errorf("failed to reconcile snapshot metadata spec ConfigMap: %w", err)
 	}
 	return nil
+}
+
+func adjustPluginCpuResourcesForIbmZ(resources any, adjustFactor float64) {
+	if resources == nil {
+		return
+	}
+	for _, req := range resourceRequirementsFromStruct(resources) {
+		adjustCpuResourcesForIbmZ(req, adjustFactor)
+	}
+}
+
+func resourceRequirementsFromStruct(spec any) []*corev1.ResourceRequirements {
+	v := reflect.ValueOf(spec).Elem()
+	reqs := make([]*corev1.ResourceRequirements, 0, v.NumField())
+	for i := 0; i < v.NumField(); i++ {
+		req, ok := v.Field(i).Interface().(*corev1.ResourceRequirements)
+		if ok && req != nil {
+			reqs = append(reqs, req)
+		}
+	}
+	return reqs
+}
+
+func adjustCpuResourcesForIbmZ(req *corev1.ResourceRequirements, adjustFactor float64) {
+	if req == nil {
+		return
+	}
+	if cpuQty, exists := req.Requests[corev1.ResourceCPU]; exists {
+		req.Requests[corev1.ResourceCPU] = utils.AdjustCPU(cpuQty, adjustFactor)
+	}
 }

--- a/internal/controller/operatorconfigmap_controller_test.go
+++ b/internal/controller/operatorconfigmap_controller_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
 	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 
+	csiopv1 "github.com/ceph/ceph-csi-operator/api/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -531,4 +533,106 @@ func TestDeleteDelegatedCSI(t *testing.T) {
 	r := newSMSReconciler(t)
 	err := r.deleteDelegatedCSI()
 	assert.NoError(t, err)
+}
+
+func TestResourceRequirementsFromStruct(t *testing.T) {
+	t.Run("collects all controller plugin resource fields", func(t *testing.T) {
+		spec := &csiopv1.ControllerPluginResourcesSpec{
+			Attacher:      newCPUResourceRequirements("50m"),
+			Snapshotter:   newCPUResourceRequirements("50m"),
+			Resizer:       newCPUResourceRequirements("50m"),
+			Provisioner:   newCPUResourceRequirements("50m"),
+			OMapGenerator: newCPUResourceRequirements("50m"),
+			Liveness:      newCPUResourceRequirements("10m"),
+			Addons:        newCPUResourceRequirements("50m"),
+			LogRotator:    newCPUResourceRequirements("10m"),
+			Plugin:        newCPUResourceRequirements("100m"),
+		}
+
+		assertResourceRequirementsCollected(t, spec, []*corev1.ResourceRequirements{
+			spec.Attacher,
+			spec.Snapshotter,
+			spec.Resizer,
+			spec.Provisioner,
+			spec.OMapGenerator,
+			spec.Liveness,
+			spec.Addons,
+			spec.LogRotator,
+			spec.Plugin,
+		})
+	})
+
+	t.Run("collects all node plugin resource fields", func(t *testing.T) {
+		spec := &csiopv1.NodePluginResourcesSpec{
+			Registrar:  newCPUResourceRequirements("10m"),
+			Liveness:   newCPUResourceRequirements("10m"),
+			Addons:     newCPUResourceRequirements("50m"),
+			LogRotator: newCPUResourceRequirements("10m"),
+			Plugin:     newCPUResourceRequirements("100m"),
+		}
+
+		assertResourceRequirementsCollected(t, spec, []*corev1.ResourceRequirements{
+			spec.Registrar,
+			spec.Liveness,
+			spec.Addons,
+			spec.LogRotator,
+			spec.Plugin,
+		})
+	})
+
+	t.Run("collects default controller plugin template resources", func(t *testing.T) {
+		resources := templates.CSIOperatorConfigSpec.DriverSpecDefaults.ControllerPlugin.Resources
+
+		assertResourceRequirementsCollected(t, &resources, []*corev1.ResourceRequirements{
+			resources.Attacher,
+			resources.Snapshotter,
+			resources.Resizer,
+			resources.Provisioner,
+			resources.OMapGenerator,
+			resources.Addons,
+			resources.LogRotator,
+			resources.Plugin,
+		})
+	})
+
+	t.Run("collects default node plugin template resources", func(t *testing.T) {
+		resources := templates.CSIOperatorConfigSpec.DriverSpecDefaults.NodePlugin.Resources
+
+		assertResourceRequirementsCollected(t, &resources, []*corev1.ResourceRequirements{
+			resources.Registrar,
+			resources.Addons,
+			resources.LogRotator,
+			resources.Plugin,
+		})
+	})
+
+	t.Run("skips nil fields", func(t *testing.T) {
+		spec := &csiopv1.ControllerPluginResourcesSpec{
+			Attacher: newCPUResourceRequirements("50m"),
+		}
+
+		got := resourceRequirementsFromStruct(spec)
+
+		assert.Len(t, got, 1)
+		assert.Equal(t, spec.Attacher, got[0])
+	})
+}
+
+func newCPUResourceRequirements(cpu string) *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse(cpu),
+		},
+	}
+}
+
+func assertResourceRequirementsCollected(t *testing.T, spec any, want []*corev1.ResourceRequirements) {
+	t.Helper()
+
+	got := resourceRequirementsFromStruct(spec)
+
+	assert.Len(t, got, len(want))
+	for _, req := range want {
+		assert.Contains(t, got, req)
+	}
 }

--- a/pkg/utils/k8sutils.go
+++ b/pkg/utils/k8sutils.go
@@ -28,6 +28,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/red-hat-storage/ocs-operator/services/provider/api/v4/interfaces"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -217,4 +218,8 @@ func SetClusterInformation(
 	status.SetClusterName(clusterDNS.Spec.BaseDomain)
 
 	return nil
+}
+
+func AdjustCPU(cpuQty resource.Quantity, adjustFactor float64) resource.Quantity {
+	return *resource.NewMilliQuantity(int64(float64(cpuQty.MilliValue())*adjustFactor), resource.DecimalSI)
 }

--- a/pkg/utils/k8sutils_test.go
+++ b/pkg/utils/k8sutils_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestAdjustCPU(t *testing.T) {
+	tests := []struct {
+		name         string
+		cpu          string
+		adjustFactor float64
+		expected     string
+	}{
+		{
+			name:         "halves millicpu request",
+			cpu:          "100m",
+			adjustFactor: 0.5,
+			expected:     "50m",
+		},
+		{
+			name:         "truncates fractional millicpu",
+			cpu:          "25m",
+			adjustFactor: 0.5,
+			expected:     "12m",
+		},
+		{
+			name:         "halves whole cpu value",
+			cpu:          "1",
+			adjustFactor: 0.5,
+			expected:     "500m",
+		},
+		{
+			name:         "scales with custom factor",
+			cpu:          "100m",
+			adjustFactor: 0.25,
+			expected:     "25m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AdjustCPU(resource.MustParse(tt.cpu), tt.adjustFactor)
+			expected := resource.MustParse(tt.expected)
+			if got.Cmp(expected) != 0 {
+				t.Fatalf("expected %s, got %s", expected.String(), got.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Halve default CSI controller and node plugin CPU requests when the operator runs on s390x, matching the IBM Z resource adjustment in ocs-operator. The reason for this is individual CPU cores on IBM Z are more than 2X powerful than the ones on other archs.
Ref-https://redhat.atlassian.net/browse/RHSTOR-9444