### PR TITLE
feat: add VolumeAttributesClass reconciliation support

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2026-06-11T08:17:52Z"
+    createdAt: "2026-06-30T07:56:18Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -373,6 +373,7 @@ spec:
           - storage.k8s.io
           resources:
           - storageclasses
+          - volumeattributesclasses
           verbs:
           - create
           - delete

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -149,7 +150,7 @@ func main() {
 		setupLog.Error(err, "Unable to get API client")
 		os.Exit(1)
 	}
-	availCrds, err := getAvailableCRDNames(apiCtx, apiClient)
+	availCrdsOrResources, err := getAvailableCRDNames(apiCtx, apiClient)
 	if err != nil {
 		setupLog.Error(err, "Unable get a list of available CRD names")
 		os.Exit(1)
@@ -199,7 +200,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
-		Cache:  buildCacheAvailableCRDs(availCrds, defaultNamespaces, operatorNamespace),
+		Cache:  buildCacheAvailableCRDs(availCrdsOrResources, defaultNamespaces, operatorNamespace),
 
 		// servers
 		HealthProbeBindAddress: healthProbeAddr,
@@ -221,6 +222,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if isAPIResourceAvailable(mgr.GetRESTMapper(), schema.GroupVersion{Group: "storage.k8s.io", Version: "v1"}, "volumeattributesclasses") {
+		availCrdsOrResources[controller.VolumeAttributesClassResourceName] = true
+	}
+
 	setupLog.Info("setting up webhook server")
 	hookServer := mgr.GetWebhookServer()
 
@@ -234,11 +239,11 @@ func main() {
 	)
 
 	if err = (&controller.StorageClientReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		OperatorNamespace: utils.GetOperatorNamespace(),
-		OperatorPodName:   podName,
-		AvailableCrds:     availCrds,
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		OperatorNamespace:    utils.GetOperatorNamespace(),
+		OperatorPodName:      podName,
+		AvailCrdsOrResources: availCrdsOrResources,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "StorageClient")
 		os.Exit(1)
@@ -275,14 +280,14 @@ func main() {
 		Scheme:                  mgr.GetScheme(),
 		OperatorNamespace:       utils.GetOperatorNamespace(),
 		ConsolePort:             int32(consolePort),
-		AvailableCrds:           availCrds,
+		AvailableCrds:           availCrdsOrResources,
 		UpdateAlertPollInterval: alertRunnable.SetPollInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OperatorConfigMapReconciler")
 		os.Exit(1)
 	}
 
-	if availCrds[controller.MaintenanceModeCRDName] {
+	if availCrdsOrResources[controller.MaintenanceModeCRDName] {
 		if err = (&controller.MaintenanceModeReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
@@ -294,14 +299,14 @@ func main() {
 
 	if err = (&controller.CrdsPresenceReconciler{
 		Client:            mgr.GetClient(),
-		AvailableCrds:     availCrds,
+		AvailableCrds:     availCrdsOrResources,
 		ShutdownContainer: shutdownContainer,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CrdsPresence")
 		os.Exit(1)
 	}
 
-	if availCrds[controller.ObjectBucketClaimCrdName] {
+	if availCrdsOrResources[controller.ObjectBucketClaimCrdName] {
 		if err = (&controller.ObcReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
@@ -404,4 +409,9 @@ func buildCacheAvailableCRDs(
 		}
 	}
 	return cacheAvailableCrd
+}
+
+func isAPIResourceAvailable(mapper apimeta.RESTMapper, gv schema.GroupVersion, resource string) bool {
+	resources, err := mapper.ResourcesFor(gv.WithResource(resource))
+	return err == nil && len(resources) > 0
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -333,6 +333,7 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  - volumeattributesclasses
   verbs:
   - create
   - delete

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -89,6 +89,7 @@ const (
 	OdfVolumeGroupSnapshotClassCrdName = "volumegroupsnapshotclasses.groupsnapshot.storage.openshift.io"
 	ObjectBucketClaimCrdName           = "objectbucketclaims.objectbucket.io"
 	ObjectBucketCrdName                = "objectbuckets.objectbucket.io"
+	VolumeAttributesClassResourceName  = "volumeattributesclasses.storage.k8s.io"
 
 	knownFieldSize = 64
 )
@@ -115,6 +116,7 @@ var (
 		&nbv1.ObjectBucketClaim{},
 		&nbv1.ObjectBucket{},
 		&corev1.ConfigMap{},
+		&storagev1.VolumeAttributesClass{},
 	}
 )
 
@@ -130,10 +132,10 @@ type kubeObjectWithOpRecords []kubeObjectWithOpRecord
 // StorageClientReconciler reconciles a StorageClient object
 type StorageClientReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	OperatorNamespace string
-	OperatorPodName   string
-	AvailableCrds     map[string]bool
+	Scheme               *runtime.Scheme
+	OperatorNamespace    string
+	OperatorPodName      string
+	AvailCrdsOrResources map[string]bool
 
 	cache            cache.Cache
 	controller       controller.Controller
@@ -259,7 +261,10 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			),
 			builder.OnlyMetadata,
 		)
-	if r.AvailableCrds[ObjectBucketClaimCrdName] {
+	if r.AvailCrdsOrResources[VolumeAttributesClassResourceName] {
+		bldr = bldr.Owns(&storagev1.VolumeAttributesClass{})
+	}
+	if r.AvailCrdsOrResources[ObjectBucketClaimCrdName] {
 		bldr = bldr.Watches(
 			&nbv1.ObjectBucketClaim{},
 			enqueueStorageClientRequestFromOBC,
@@ -279,6 +284,7 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.crdsBeingWatched.Store(VolumeGroupSnapshotClassCrdName, false)
 	r.crdsBeingWatched.Store(OdfVolumeGroupSnapshotClassCrdName, false)
 	r.crdsBeingWatched.Store(ObjectBucketCrdName, false)
+	r.crdsBeingWatched.Store(VolumeAttributesClassResourceName, false)
 
 	return err
 }
@@ -311,6 +317,7 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=objectbucket.io,resources=objectbucketclaims/status,verbs=update;patch
 //+kubebuilder:rbac:groups=objectbucket.io,resources=objectbuckets/status,verbs=update;patch
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattributesclasses,verbs=get;list;watch;create;delete;update
 
 func (r *StorageClientReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	handler := storageClientReconcile{StorageClientReconciler: r}
@@ -361,6 +368,10 @@ func (r *storageClientReconcile) reconcileDynamicWatches() error {
 	}
 
 	if err := r.setupObjectBucketWatch(); err != nil {
+		return err
+	}
+
+	if err := r.setupVolumeAttributesClassWatch(); err != nil {
 		return err
 	}
 
@@ -543,6 +554,41 @@ func (r *storageClientReconcile) setupObjectBucketWatch() error {
 	}
 
 	r.crdsBeingWatched.Store(ObjectBucketCrdName, true)
+	return nil
+}
+
+func (r *storageClientReconcile) setupVolumeAttributesClassWatch() error {
+	if watchExists, found := r.crdsBeingWatched.Load(VolumeAttributesClassResourceName); !found || watchExists.(bool) {
+		return nil
+	}
+
+	vacList := &storagev1.VolumeAttributesClassList{}
+	if err := r.list(vacList, client.Limit(1)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+		return err
+	}
+
+	if err := r.controller.Watch(
+		source.Kind(
+			r.cache,
+			client.Object(&storagev1.VolumeAttributesClass{}),
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, o client.Object) []ctrl.Request {
+				owner := metav1.GetControllerOf(o)
+				if owner != nil &&
+					owner.Kind == "StorageClient" &&
+					owner.APIVersion == v1alpha1.GroupVersion.String() {
+					return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: owner.Name}}}
+				}
+				return nil
+			}),
+		),
+	); err != nil {
+		return fmt.Errorf("failed to setup dynamic watch on VolumeAttributesClass: %v", err)
+	}
+
+	r.crdsBeingWatched.Store(VolumeAttributesClassResourceName, true)
 	return nil
 }
 

--- a/internal/controller/storageclient_controller_test.go
+++ b/internal/controller/storageclient_controller_test.go
@@ -1,0 +1,364 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/red-hat-storage/ocs-client-operator/api/v1alpha1"
+	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
+
+	provider "github.com/red-hat-storage/ocs-operator/services/provider/api/v4"
+	"github.com/stretchr/testify/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func newFakeStorageClientReconcile(t *testing.T, objs ...client.Object) *storageClientReconcile {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	err := kubescheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = v1alpha1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	storageClient := v1alpha1.StorageClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-storageclient",
+			UID:  "test-uid-12345",
+		},
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objs) > 0 {
+		builder = builder.WithObjects(objs...)
+	}
+	fakeClient := builder.Build()
+
+	return &storageClientReconcile{
+		StorageClientReconciler: &StorageClientReconciler{
+			Client: fakeClient,
+			Scheme: scheme,
+		},
+		ctx:           context.Background(),
+		log:           ctrllog.Log.WithName("storageclient_controller_test"),
+		storageClient: storageClient,
+	}
+}
+
+func newVolumeAttributesClassBytes(t *testing.T, name, driverName string, params map[string]string) []byte {
+	t.Helper()
+	vac := storagev1.VolumeAttributesClass{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "storage.k8s.io/v1",
+			Kind:       "VolumeAttributesClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		DriverName: driverName,
+		Parameters: params,
+	}
+	data, err := json.Marshal(vac)
+	assert.NoError(t, err)
+	return data
+}
+
+func TestReconcileResourcesByGK_VolumeAttributesClass_Create(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+
+	vacBytes := newVolumeAttributesClassBytes(t, "test-vac", templates.RBDDriverName, map[string]string{
+		"iopsPerGB": "10",
+	})
+
+	desiredObjects := map[string]kubeObjectWithOpRecords{
+		"VolumeAttributesClass.storage.k8s.io": {
+			{
+				NamespacedName: types.NamespacedName{Name: "test-vac"},
+				bytes:          vacBytes,
+				operation:      provider.KubeClientOp_CREATE_OR_UPDATE,
+			},
+		},
+	}
+
+	var combinedErr error
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+
+	created := &storagev1.VolumeAttributesClass{}
+	err := r.Get(r.ctx, types.NamespacedName{Name: "test-vac"}, created)
+	assert.NoError(t, err)
+	assert.Equal(t, templates.RBDDriverName, created.DriverName)
+	assert.Equal(t, "10", created.Parameters["iopsPerGB"])
+	assert.True(t, metav1.IsControlledBy(created, &r.storageClient))
+}
+
+func TestReconcileResourcesByGK_VolumeAttributesClass_Update(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+
+	initialBytes := newVolumeAttributesClassBytes(t, "test-vac", templates.RBDDriverName, map[string]string{
+		"iopsPerGB": "10",
+	})
+	desiredObjects := map[string]kubeObjectWithOpRecords{
+		"VolumeAttributesClass.storage.k8s.io": {
+			{
+				NamespacedName: types.NamespacedName{Name: "test-vac"},
+				bytes:          initialBytes,
+				operation:      provider.KubeClientOp_CREATE_OR_UPDATE,
+			},
+		},
+	}
+	var combinedErr error
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+
+	updatedBytes := newVolumeAttributesClassBytes(t, "test-vac", templates.RBDDriverName, map[string]string{
+		"iopsPerGB": "20",
+	})
+	desiredObjects["VolumeAttributesClass.storage.k8s.io"] = kubeObjectWithOpRecords{
+		{
+			NamespacedName: types.NamespacedName{Name: "test-vac"},
+			bytes:          updatedBytes,
+			operation:      provider.KubeClientOp_CREATE_OR_UPDATE,
+		},
+	}
+
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+
+	updated := &storagev1.VolumeAttributesClass{}
+	err := r.Get(r.ctx, types.NamespacedName{Name: "test-vac"}, updated)
+	assert.NoError(t, err)
+	assert.Equal(t, "20", updated.Parameters["iopsPerGB"])
+}
+
+func TestReconcileResourcesByGK_VolumeAttributesClass_DeleteOrphan(t *testing.T) {
+	storageClient := v1alpha1.StorageClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-storageclient",
+			UID:  "test-uid-12345",
+		},
+	}
+
+	orphanVAC := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orphan-vac",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1alpha1.GroupVersion.String(),
+					Kind:               "StorageClient",
+					Name:               storageClient.Name,
+					UID:                storageClient.UID,
+					Controller:         boolPtr(true),
+					BlockOwnerDeletion: boolPtr(true),
+				},
+			},
+		},
+		DriverName: templates.RBDDriverName,
+		Parameters: map[string]string{"iopsPerGB": "5"},
+	}
+
+	r := newFakeStorageClientReconcile(t, orphanVAC)
+
+	desiredObjects := map[string]kubeObjectWithOpRecords{}
+
+	var combinedErr error
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+
+	deleted := &storagev1.VolumeAttributesClass{}
+	err := r.Get(r.ctx, types.NamespacedName{Name: "orphan-vac"}, deleted)
+	assert.Error(t, err, "orphaned VolumeAttributesClass should be deleted")
+}
+
+func TestReconcileResourcesByGK_VolumeAttributesClass_PreserveUnowned(t *testing.T) {
+	unownedVAC := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unowned-vac",
+		},
+		DriverName: templates.RBDDriverName,
+		Parameters: map[string]string{"iopsPerGB": "5"},
+	}
+
+	r := newFakeStorageClientReconcile(t, unownedVAC)
+
+	desiredObjects := map[string]kubeObjectWithOpRecords{}
+
+	var combinedErr error
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+
+	preserved := &storagev1.VolumeAttributesClass{}
+	err := r.Get(r.ctx, types.NamespacedName{Name: "unowned-vac"}, preserved)
+	assert.NoError(t, err, "unowned VolumeAttributesClass should not be deleted")
+}
+
+func TestReconcileResourcesByGK_VolumeAttributesClass_MultipleObjects(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+
+	vac1Bytes := newVolumeAttributesClassBytes(t, "vac-gold", templates.RBDDriverName, map[string]string{
+		"iopsPerGB": "50",
+	})
+	vac2Bytes := newVolumeAttributesClassBytes(t, "vac-silver", templates.RBDDriverName, map[string]string{
+		"iopsPerGB": "10",
+	})
+
+	desiredObjects := map[string]kubeObjectWithOpRecords{
+		"VolumeAttributesClass.storage.k8s.io": {
+			{
+				NamespacedName: types.NamespacedName{Name: "vac-gold"},
+				bytes:          vac1Bytes,
+				operation:      provider.KubeClientOp_CREATE_OR_UPDATE,
+			},
+			{
+				NamespacedName: types.NamespacedName{Name: "vac-silver"},
+				bytes:          vac2Bytes,
+				operation:      provider.KubeClientOp_CREATE_OR_UPDATE,
+			},
+		},
+	}
+
+	var combinedErr error
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+
+	gold := &storagev1.VolumeAttributesClass{}
+	err := r.Get(r.ctx, types.NamespacedName{Name: "vac-gold"}, gold)
+	assert.NoError(t, err)
+	assert.Equal(t, templates.RBDDriverName, gold.DriverName)
+	assert.Equal(t, "50", gold.Parameters["iopsPerGB"])
+
+	silver := &storagev1.VolumeAttributesClass{}
+	err = r.Get(r.ctx, types.NamespacedName{Name: "vac-silver"}, silver)
+	assert.NoError(t, err)
+	assert.Equal(t, templates.RBDDriverName, silver.DriverName)
+	assert.Equal(t, "10", silver.Parameters["iopsPerGB"])
+}
+
+func TestReconcileResourcesByGK_VolumeAttributesClass_NoDesiredState(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+
+	desiredObjects := map[string]kubeObjectWithOpRecords{}
+
+	var combinedErr error
+	r.reconcileResourcesByGK(&storagev1.VolumeAttributesClass{}, desiredObjects, &combinedErr)
+	assert.NoError(t, combinedErr)
+}
+
+func TestKindsToReconcileContainsVolumeAttributesClass(t *testing.T) {
+	found := false
+	for _, kind := range kindsToReconcile {
+		if _, ok := kind.(*storagev1.VolumeAttributesClass); ok {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "kindsToReconcile must contain VolumeAttributesClass")
+}
+
+func TestSetupVolumeAttributesClassWatch_SkipsWhenNotRegistered(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+
+	err := r.setupVolumeAttributesClassWatch()
+	assert.NoError(t, err)
+
+	_, found := r.crdsBeingWatched.Load(VolumeAttributesClassResourceName)
+	assert.False(t, found, "should not be registered in crdsBeingWatched")
+}
+
+func TestSetupVolumeAttributesClassWatch_SkipsWhenAlreadyWatching(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+	r.crdsBeingWatched.Store(VolumeAttributesClassResourceName, true)
+
+	err := r.setupVolumeAttributesClassWatch()
+	assert.NoError(t, err)
+
+	val, _ := r.crdsBeingWatched.Load(VolumeAttributesClassResourceName)
+	assert.True(t, val.(bool), "should remain true (already watching)")
+}
+
+func TestSetupVolumeAttributesClassWatch_SkipsOnNoMatchError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := kubescheme.AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = v1alpha1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	noMatchErr := &meta.NoResourceMatchError{
+		PartialResource: schema.GroupVersionResource{
+			Group:    "storage.k8s.io",
+			Version:  "v1",
+			Resource: "volumeattributesclasses",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*storagev1.VolumeAttributesClassList); ok {
+					return noMatchErr
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	r := &storageClientReconcile{
+		StorageClientReconciler: &StorageClientReconciler{
+			Client: fakeClient,
+			Scheme: scheme,
+		},
+		ctx: context.Background(),
+		log: ctrllog.Log.WithName("storageclient_controller_test"),
+	}
+	r.crdsBeingWatched.Store(VolumeAttributesClassResourceName, false)
+
+	err = r.setupVolumeAttributesClassWatch()
+	assert.NoError(t, err)
+
+	val, _ := r.crdsBeingWatched.Load(VolumeAttributesClassResourceName)
+	assert.False(t, val.(bool), "should remain false when API is not available")
+}
+
+func TestCrdsBeingWatched_RegisteredWhenVACUnavailable(t *testing.T) {
+	r := &StorageClientReconciler{
+		AvailCrdsOrResources: map[string]bool{},
+	}
+
+	if !r.AvailCrdsOrResources[VolumeAttributesClassResourceName] {
+		r.crdsBeingWatched.Store(VolumeAttributesClassResourceName, false)
+	}
+
+	val, found := r.crdsBeingWatched.Load(VolumeAttributesClassResourceName)
+	assert.True(t, found, "should be registered in crdsBeingWatched")
+	assert.False(t, val.(bool), "should be false (not yet watching)")
+}
+
+func TestCrdsBeingWatched_NotRegisteredWhenVACAvailable(t *testing.T) {
+	r := &StorageClientReconciler{
+		AvailCrdsOrResources: map[string]bool{
+			VolumeAttributesClassResourceName: true,
+		},
+	}
+
+	if !r.AvailCrdsOrResources[VolumeAttributesClassResourceName] {
+		r.crdsBeingWatched.Store(VolumeAttributesClassResourceName, false)
+	}
+
+	_, found := r.crdsBeingWatched.Load(VolumeAttributesClassResourceName)
+	assert.False(t, found, "should not be in crdsBeingWatched when already available")
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Add conditional VolumeAttributesClass (storage.k8s.io/v1) support to the StorageClient controller. The API availability is checked at startup via REST mapper and dynamically during reconciliation, ensuring the operator works on clusters where the API is not yet available (K8s <1.34).