### PR TITLE
[main] Bump go (stdlib) from 1.26.1 to 1.26.3

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.26.1
+go 1.26.3
 
 require k8s.io/apimachinery v0.35.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.26.1
+go 1.26.3
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.26.1` → `1.26.3` (in `api/go.mod`)
- **go (stdlib)**: `1.26.1` → `1.26.3` (in `go.mod`)
