### PR TITLE
DFBUGS-8403: [release-4.16] Bump go (stdlib) from 1.21.9 to 1.21.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.21.9
+go 1.21.13
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.21.9` → `1.21.13` (in `go.mod`)
