### PR TITLE
[release-4.17] Bump go (stdlib) from 1.22.5 to 1.22.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.22.5
+go 1.22.12
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.22.5` → `1.22.12` (in `go.mod`)
