### PR TITLE
[release-4.18] Bump go (stdlib) from 1.22.5 to 1.22.12

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.22.5
+go 1.22.12
 
 require k8s.io/apimachinery v0.31.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.22.7
+go 1.22.12
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.22.5
 github.com/ramendr/ramen/api/v1alpha1
 # github.com/red-hat-storage/ocs-client-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.22.5
+## explicit; go 1.22.12
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20241120160011-2e7cf0127dd4
 ## explicit; go 1.22.7


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.22.5` → `1.22.12` (in `api/go.mod`)
- **go (stdlib)**: `1.22.7` → `1.22.12` (in `go.mod`)
