### PR TITLE
[release-4.20] Bump go (stdlib) from 1.23.1 to 1.23.10

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.23.1
+go 1.23.10
 
 require k8s.io/apimachinery v0.31.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-client-operator
 
 go 1.24.3
 
-toolchain go1.24.5
+toolchain go1.24.8
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -255,7 +255,7 @@ github.com/ramendr/ramen/api/v1alpha1
 ## explicit; go 1.22.0
 github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1
 # github.com/red-hat-storage/ocs-client-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.23.1
+## explicit; go 1.23.10
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20251009102644-5727239a7b48
 ## explicit; go 1.24.3


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.1` → `1.23.10` (in `api/go.mod`)
- **go (stdlib)**: `1.24.5` → `1.24.8` (in `go.mod`)
