### PR TITLE
[release-4.22] Bump go (stdlib) from 1.25.2 to 1.25.6

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.25.2
+go 1.25.6
 
 require k8s.io/apimachinery v0.31.0
 


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.2` → `1.25.6` (in `api/go.mod`)
