### PR TITLE
[release-4.21] Bump go (stdlib) from 1.24.6 to 1.24.12

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator/api
 
-go 1.24.6
+go 1.24.12
 
 require k8s.io/apimachinery v0.31.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-client-operator
 
-go 1.24.6
+go 1.24.12
 
 replace (
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by Rook v1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/ramendr/ramen/api/v1alpha1
 ## explicit; go 1.22.0
 github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1
 # github.com/red-hat-storage/ocs-client-operator/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.24.6
+## explicit; go 1.24.12
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/services/provider/api/v4 v4.0.0-20251126052642-f8ae02a1c7e4
 ## explicit; go 1.24.6


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.6` → `1.24.12` (in `api/go.mod`)
- **go (stdlib)**: `1.24.6` → `1.24.12` (in `go.mod`)
