### PR TITLE
reduce and relax commitlint rules for gh action

### DIFF
--- a/.github/workflows/conf/commitlintrc.json
+++ b/.github/workflows/conf/commitlintrc.json
@@ -8,16 +8,12 @@
             "always",
             "lower-case"
         ],
-        "body-empty": [
-            1,
-            "never"
-        ],
         "body-leading-blank": [
             2,
             "always"
         ],
         "body-max-line-length": [
-            1,
+            2,
             "always",
             72
         ],
@@ -29,11 +25,6 @@
             0,
             "always",
             "lower-case"
-        ],
-        "header-full-stop": [
-            2,
-            "never",
-            "."
         ],
         "header-max-length": [
             2,
@@ -62,6 +53,17 @@
         "type-empty": [
             0,
             "never"
+        ],
+        "type-enum": [
+            0
+        ],
+        "subject-full-stop": [
+            0
+        ],
+        "footer-max-line-length": [
+            2,
+            "always",
+            72
         ]
     }
 }


### PR DESCRIPTION

| Rule | Catches |
| :--- | :--- |
| body-leading-blank | missing blank line between subject and body |
| body-max-line-length | body lines > 72 chars |
| footer-leading-blank | missing blank line before footer (sign-off) |
| footer-max-line-length | footer lines > 72 chars |
| header-max-length | subject > 72 chars |
| header-trim | leading/trailing whitespace in subject |
| signed-off-by | missing Signed-off-by: |
