### PR TITLE
ci: skip commitlint for dependabot PRs [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       - "dependencies"
       - "go"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
 
   # GitHub Actions
@@ -47,5 +47,5 @@ updates:
       - "dependencies"
       - "github-actions"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"

--- a/.github/workflows/lint-and-spellcheck.yaml
+++ b/.github/workflows/lint-and-spellcheck.yaml
@@ -29,6 +29,7 @@ jobs:
   commitlint:
     name: commitlint
     runs-on: ubuntu-latest
+    if: github.triggering_actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:


### PR DESCRIPTION
dependabot PRs aren't following commit-lint rules rather than accommodating rules or configuring dependabot better not lint prs raised by dependabot.