### PR TITLE
controller: pass subscription nodeSelector to status-reporter cronjob

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -883,6 +883,7 @@ func (r *storageClientReconcile) reconcileClientStatusReporterJob(operatorVersio
 							},
 							RestartPolicy:      corev1.RestartPolicyOnFailure,
 							ServiceAccountName: "ocs-client-operator-status-reporter",
+							NodeSelector:       ptr.Deref(clientSubscription.Spec.Config, opv1a1.SubscriptionConfig{}).NodeSelector,
 							Tolerations: append(
 								[]corev1.Toleration{
 									{


### PR DESCRIPTION
Similar to tolerations, propagate the nodeSelector from the subscription config to the CronJob pod spec.