### PR TITLE
fix: clear absent provider fields on reconcile

### DIFF
--- a/internal/controller/reconcile_resource_test.go
+++ b/internal/controller/reconcile_resource_test.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/red-hat-storage/ocs-client-operator/pkg/templates"
+)
+
+func marshalVAC(t *testing.T, vac *storagev1.VolumeAttributesClass) []byte {
+	t.Helper()
+	b, err := json.Marshal(vac)
+	assert.NoError(t, err)
+	return b
+}
+
+func vacTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{APIVersion: "storage.k8s.io/v1", Kind: "VolumeAttributesClass"}
+}
+
+// TestReconcileResource_PreservesNamespacedName verifies that name and namespace
+// are restored after zeroing even when the provider bytes omit them due to omitempty.
+func TestReconcileResource_PreservesNamespacedName(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "test-ns",
+		},
+	}
+	r := newFakeStorageClientReconcile(t, existing)
+
+	// Marshal a ConfigMap with empty namespace; omitempty drops it from JSON.
+	desired := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm"},
+	}
+	b, err := json.Marshal(desired)
+	assert.NoError(t, err)
+
+	err = r.reconcileResource(
+		&corev1.ConfigMap{},
+		b,
+		types.NamespacedName{Name: "test-cm", Namespace: "test-ns"},
+	)
+	assert.NoError(t, err)
+
+	result := &corev1.ConfigMap{}
+	assert.NoError(t, r.Get(r.ctx, types.NamespacedName{Name: "test-cm", Namespace: "test-ns"}, result))
+	assert.Equal(t, "test-cm", result.Name, "name must be restored from namespacedName after zero")
+	assert.Equal(t, "test-ns", result.Namespace, "namespace must be restored from namespacedName after zero")
+}
+
+// TestReconcileResource_ClearsAbsentFields is the regression test for the
+// read-affinity class of bugs: a field present on the live object but absent
+// from the provider response must be cleared, not silently retained.
+func TestReconcileResource_ClearsAbsentFields(t *testing.T) {
+	existing := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vac"},
+		DriverName: templates.RBDDriverName,
+		Parameters: map[string]string{"iopsPerGB": "10"},
+	}
+	r := newFakeStorageClientReconcile(t, existing)
+
+	// Parameters omitempty: nil map is absent from JSON, mimicking a provider
+	// that no longer sends this field (e.g. readAffinity disabled).
+	desired := &storagev1.VolumeAttributesClass{
+		TypeMeta:   vacTypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vac"},
+		DriverName: templates.RBDDriverName,
+	}
+	err := r.reconcileResource(
+		&storagev1.VolumeAttributesClass{},
+		marshalVAC(t, desired),
+		types.NamespacedName{Name: "test-vac"},
+	)
+	assert.NoError(t, err)
+
+	result := &storagev1.VolumeAttributesClass{}
+	assert.NoError(t, r.Get(r.ctx, types.NamespacedName{Name: "test-vac"}, result))
+	assert.Empty(t, result.Parameters, "field absent from provider response must be cleared on the live object")
+}
+
+// TestReconcileResource_PreservesMetadata verifies that labels, annotations,
+// and finalizers set externally on the live object survive a reconcile even
+// when the provider response carries none of them.
+func TestReconcileResource_PreservesMetadata(t *testing.T) {
+	existing := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-vac",
+			Labels:      map[string]string{"external": "label"},
+			Annotations: map[string]string{"external": "annotation"},
+			Finalizers:  []string{"some-controller/finalizer"},
+		},
+		DriverName: templates.RBDDriverName,
+	}
+	r := newFakeStorageClientReconcile(t, existing)
+
+	desired := &storagev1.VolumeAttributesClass{
+		TypeMeta:   vacTypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vac"},
+		DriverName: templates.RBDDriverName,
+	}
+	err := r.reconcileResource(
+		&storagev1.VolumeAttributesClass{},
+		marshalVAC(t, desired),
+		types.NamespacedName{Name: "test-vac"},
+	)
+	assert.NoError(t, err)
+
+	result := &storagev1.VolumeAttributesClass{}
+	assert.NoError(t, r.Get(r.ctx, types.NamespacedName{Name: "test-vac"}, result))
+	assert.Equal(t, "label", result.Labels["external"], "labels must be preserved across reconcile")
+	assert.Equal(t, "annotation", result.Annotations["external"], "annotations must be preserved across reconcile")
+	assert.Contains(t, result.Finalizers, "some-controller/finalizer", "finalizers must be preserved across reconcile")
+}

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -1080,16 +1080,38 @@ func (r *storageClientReconcile) reconcileResourcesByGK(
 func (r *storageClientReconcile) reconcileResource(obj client.Object, desiredObjectBytes []byte, namespacedName types.NamespacedName) error {
 
 	mutateFunc := func() error {
-		// Unmarshal follows merge semantics, that means that we don't need to worry about overriding the status,
-		// or any metadata fields. There is an exception when it comes to creationTimestamp which gets serialized into
-		// default value.
+		// Preserve metadata that must survive provider updates.
+		labels := obj.GetLabels()
+		annotations := obj.GetAnnotations()
+		ownerRefs := obj.GetOwnerReferences()
+		finalizers := obj.GetFinalizers()
+		uid := obj.GetUID()
 		creationTimestamp := obj.GetCreationTimestamp()
+		resourceVersion := obj.GetResourceVersion()
+
+		// Zero the object so absent fields in the response clear existing
+		// values rather than being silently retained via merge accumulation.
+		goType := reflect.TypeOf(obj).Elem()    // concrete struct type, e.g. CephConnection not *CephConnection
+		zeroValue := reflect.New(goType).Elem() // zeroed struct value of that type
+		objValue := reflect.ValueOf(obj).Elem() // addressable struct value behind obj's pointer
+		objValue.Set(zeroValue)                 // reset in-place, same pointer CreateOrUpdate holds
+
 		if err := json.Unmarshal(desiredObjectBytes, obj); err != nil {
-			return fmt.Errorf("failed to unmarshal %s configuration response: %v", obj.GetName(), err)
+			return fmt.Errorf("failed to unmarshal %s configuration response: %v", namespacedName.Name, err)
 		}
+
+		obj.SetName(namespacedName.Name)
+		obj.SetNamespace(namespacedName.Namespace)
+		obj.SetLabels(labels)
+		obj.SetAnnotations(annotations)
+		obj.SetOwnerReferences(ownerRefs)
+		obj.SetFinalizers(finalizers)
+		obj.SetUID(uid)
 		obj.SetCreationTimestamp(creationTimestamp)
+		obj.SetResourceVersion(resourceVersion)
+
 		if err := r.own(obj); err != nil {
-			return fmt.Errorf("failed to own %s resource: %v", obj.GetName(), err)
+			return fmt.Errorf("failed to own %s resource: %v", namespacedName.Name, err)
 		}
 		return nil
 	}


### PR DESCRIPTION
Zero object before unmarshal so disabled fields (e.g. readAffinity) are cleared on the live object rather than silently retained via json merge accumulation. Preserve labels, annotations, ownerRefs, resourceVersion and creationTimestamp across the reset.

Tests are generated by AI.