### PR TITLE
controller: fetch package name from deployment annotations

### DIFF
--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -1165,20 +1165,13 @@ func (r *storageClientReconcile) getOperatorVersion() (string, error) {
 	if err := r.get(deployment); err != nil {
 		return "", fmt.Errorf("failed to get deployment: %v", err)
 	}
-	ownerCsvIdx := slices.IndexFunc(deployment.OwnerReferences, func(owner metav1.OwnerReference) bool {
-		return owner.Kind == "ClusterServiceVersion"
-	})
-	if ownerCsvIdx == -1 {
-		return "", fmt.Errorf("unable to find csv from deployment owners")
+
+	// TODO: Add a version package
+	if version, ok := deployment.Annotations["olm.operatorframework.io/bundle-version"]; ok {
+		return version, nil
 	}
 
-	csv := &opv1a1.ClusterServiceVersion{}
-	csv.Name = deployment.OwnerReferences[ownerCsvIdx].Name
-	csv.Namespace = r.OperatorNamespace
-	if err := r.get(csv); err != nil {
-		return "", fmt.Errorf("failed to get csv: %v", err)
-	}
-	return csv.Spec.Version.String(), nil
+	return "", fmt.Errorf("failed to get version from deployment: %v", deployment.Name)
 }
 
 // crdEstablished reports whether the CRD is served by the apiserver (status.conditions Established=True).


### PR DESCRIPTION
Starting with OLM v1, retrieve the bundle version from deployment annotations instead of CSVs.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

```
$ oc get deployment ocs-client-operator-controller-manager -oyaml | yq .metadata
annotations:
  deployment.kubernetes.io/revision: "1"
  olm.operatorframework.io/bundle-version: 4.22.0
  olm.operatorframework.io/package-name: ocs-client-operator
  olm.operatorframework.io/revision: "2"
creationTimestamp: "2026-07-21T07:52:23Z"
generation: 3
labels:
  app: ocs-client-operator
  app.kubernetes.io/managed-by: boxcutter
  control-plane: controller-manager
  olm.operatorframework.io/owner-kind: ClusterExtension
  olm.operatorframework.io/owner-name: ocs-client-operator
name: ocs-client-operator-controller-manager
namespace: openshift-storage
ownerReferences:
  - apiVersion: olm.operatorframework.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ClusterObjectSet
    name: ocs-client-operator-2
    uid: 23a55997-ffda-4c16-bac8-5c48aef28546
resourceVersion: "213843"
uid: 90d29957-6bcd-42bc-be4e-f99492bc556d
```