### PR TITLE
Add delete verb to clusterresourcequotas RBAC permissions

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2026-07-24T05:03:21Z"
+    createdAt: "2026-07-27T07:15:38Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -304,6 +304,7 @@ spec:
           - clusterresourcequotas
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -264,6 +264,7 @@ rules:
   - clusterresourcequotas
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -290,7 +290,7 @@ func (r *StorageClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return err
 }
 
-//+kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclients,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclients/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclients/finalizers,verbs=update


### PR DESCRIPTION
[DFBUGS-8953](https://redhat.atlassian.net/browse/DFBUGS-8953)
Add the missing 'delete' verb to the ClusterResourceQuota RBAC permissions.Without it, the operator cannot delete the ClusterResourceQuota when a client cluster's storage quota is changed from custom to unlimited.
