### PR TITLE
console: lower ocs-client-console CPU request from 50m to 10m

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -564,7 +564,7 @@ spec:
                     cpu: 250m
                     memory: 512Mi
                   requests:
-                    cpu: 50m
+                    cpu: 10m
                     memory: 256Mi
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -49,8 +49,8 @@ spec:
               cpu: "250m"
               memory: "512Mi"
             requests:
-              cpu: 50m
-              memory: 256Mi
+              cpu: "10m"
+              memory: "256Mi"
           livenessProbe:
             httpGet:
               path: /plugin-manifest.json


### PR DESCRIPTION
The console is nginx serving static OpenShift plugin assets, idle most of the time. The S3 path added in #524 only proxies Object Browser management APIs (list/ACL/lifecycle/etc.) to the provider — GetObject/PutObject are blocked, traffic is UI-driven and rate-capped at 50 r/s, so it is not a data-plane gateway. That matches #421’s original 10m (usage <5m in tests) and odf-console/console-plugin-template; keep the higher 250m limit for occasional TLS bursts, not a higher request.

Ref-https://redhat.atlassian.net/browse/RHSTOR-9519