### PR TITLE
preserve merge semantics for resource labels and annotations

### DIFF
--- a/internal/controller/reconcile_resource_test.go
+++ b/internal/controller/reconcile_resource_test.go
@@ -119,3 +119,67 @@ func TestReconcileResource_PreservesMetadata(t *testing.T) {
 	assert.Equal(t, "annotation", result.Annotations["external"], "annotations must be preserved across reconcile")
 	assert.Contains(t, result.Finalizers, "some-controller/finalizer", "finalizers must be preserved across reconcile")
 }
+
+// TestReconcileResource_AppliesProviderLabelsOnCreate verifies provider labels are applied when creating new objects.
+func TestReconcileResource_AppliesProviderLabelsOnCreate(t *testing.T) {
+	r := newFakeStorageClientReconcile(t)
+
+	desired := &storagev1.VolumeAttributesClass{
+		TypeMeta: vacTypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-vac",
+			Labels:      map[string]string{"provider": "label", "version": "1"},
+			Annotations: map[string]string{"provider": "anno"},
+		},
+		DriverName: templates.RBDDriverName,
+	}
+	err := r.reconcileResource(
+		&storagev1.VolumeAttributesClass{},
+		marshalVAC(t, desired),
+		types.NamespacedName{Name: "test-vac"},
+	)
+	assert.NoError(t, err)
+
+	result := &storagev1.VolumeAttributesClass{}
+	assert.NoError(t, r.Get(r.ctx, types.NamespacedName{Name: "test-vac"}, result))
+	assert.Equal(t, "label", result.Labels["provider"], "provider labels must be applied on create")
+	assert.Equal(t, "1", result.Labels["version"], "all provider labels must be applied on create")
+	assert.Equal(t, "anno", result.Annotations["provider"], "provider annotations must be applied on create")
+}
+
+// TestReconcileResource_MergesLabelsOnUpdate verifies provider labels override but external labels preserved on update.
+func TestReconcileResource_MergesLabelsOnUpdate(t *testing.T) {
+	existing := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-vac",
+			Labels:      map[string]string{"external": "label", "version": "old"},
+			Annotations: map[string]string{"external": "anno"},
+		},
+		DriverName: templates.RBDDriverName,
+	}
+	r := newFakeStorageClientReconcile(t, existing)
+
+	desired := &storagev1.VolumeAttributesClass{
+		TypeMeta: vacTypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-vac",
+			Labels:      map[string]string{"version": "new", "provider": "label"},
+			Annotations: map[string]string{"provider": "anno"},
+		},
+		DriverName: templates.RBDDriverName,
+	}
+	err := r.reconcileResource(
+		&storagev1.VolumeAttributesClass{},
+		marshalVAC(t, desired),
+		types.NamespacedName{Name: "test-vac"},
+	)
+	assert.NoError(t, err)
+
+	result := &storagev1.VolumeAttributesClass{}
+	assert.NoError(t, r.Get(r.ctx, types.NamespacedName{Name: "test-vac"}, result))
+	assert.Equal(t, "label", result.Labels["external"], "external labels must be preserved")
+	assert.Equal(t, "new", result.Labels["version"], "provider labels override external")
+	assert.Equal(t, "label", result.Labels["provider"], "new provider labels added")
+	assert.Equal(t, "anno", result.Annotations["external"], "external annotations preserved")
+	assert.Equal(t, "anno", result.Annotations["provider"], "provider annotations applied")
+}

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -1077,6 +1077,29 @@ func (r *storageClientReconcile) reconcileResourcesByGK(
 	}
 }
 
+func mergeLabelsAnnotations(obj client.Object, externalLabels, externalAnnotations map[string]string) {
+	finalLabels := make(map[string]string)
+	finalAnnotations := make(map[string]string)
+
+	for k, v := range externalLabels {
+		finalLabels[k] = v
+	}
+	for k, v := range externalAnnotations {
+		finalAnnotations[k] = v
+	}
+
+	// server sent labels and annotations takes precedence
+	for k, v := range obj.GetLabels() {
+		finalLabels[k] = v
+	}
+	for k, v := range obj.GetAnnotations() {
+		finalAnnotations[k] = v
+	}
+
+	obj.SetLabels(finalLabels)
+	obj.SetAnnotations(finalAnnotations)
+}
+
 func (r *storageClientReconcile) reconcileResource(obj client.Object, desiredObjectBytes []byte, namespacedName types.NamespacedName) error {
 
 	mutateFunc := func() error {
@@ -1102,13 +1125,13 @@ func (r *storageClientReconcile) reconcileResource(obj client.Object, desiredObj
 
 		obj.SetName(namespacedName.Name)
 		obj.SetNamespace(namespacedName.Namespace)
-		obj.SetLabels(labels)
-		obj.SetAnnotations(annotations)
 		obj.SetOwnerReferences(ownerRefs)
 		obj.SetFinalizers(finalizers)
 		obj.SetUID(uid)
 		obj.SetCreationTimestamp(creationTimestamp)
 		obj.SetResourceVersion(resourceVersion)
+
+		mergeLabelsAnnotations(obj, labels, annotations)
 
 		if err := r.own(obj); err != nil {
 			return fmt.Errorf("failed to own %s resource: %v", namespacedName.Name, err)


### PR DESCRIPTION
when object doesn't exist transfer the server sent labels and annotations, when obj do exist, merge it with live object with server sent values taking precedence.

regression from #676