### PR TITLE
console: configure client console nginx TLS from TLSProfile CR

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,10 +7,11 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2026-07-27T07:15:38Z"
+    createdAt: "2026-08-10T13:46:39Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
+    features.operators.openshift.io/tls-profiles: "true"
     olm.skipRange: ""
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/builder: operator-sdk-v1.34.1

--- a/config/manifests/bases/ocs-client-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ocs-client-operator.clusterserviceversion.yaml
@@ -10,6 +10,7 @@ metadata:
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
+    features.operators.openshift.io/tls-profiles: "true"
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/operator-type: standalone
     repository: https://github.com/red-hat-storage/ocs-client-operator

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -867,6 +867,12 @@ func (c *OperatorConfigMapReconciler) ensureConsolePlugin() error {
 		return err
 	}
 
+	goTLS, err := utils.BuildServerTLSOpts(c.TlsProfile, "ocs.openshift.io", "client-console")
+	if err != nil {
+		return fmt.Errorf("invalid TLSProfile config for console nginx: %w", err)
+	}
+	ossl := ocstlsv1.OpenSSLConfigFrom(goTLS)
+
 	nginxConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      console.NginxConfigMapName,
@@ -874,7 +880,7 @@ func (c *OperatorConfigMapReconciler) ensureConsolePlugin() error {
 		},
 	}
 	nginxConfigMapResult, err := c.createOrUpdateWithResult(nginxConfigMap, func() error {
-		desiredData, buildErr := c.buildDesiredNginxDataWithProxies()
+		desiredData, buildErr := c.buildDesiredNginxDataWithProxies(ossl)
 		if buildErr != nil {
 			return buildErr
 		}
@@ -922,10 +928,14 @@ func (c *OperatorConfigMapReconciler) ensureConsolePlugin() error {
 	return nil
 }
 
-func (c *OperatorConfigMapReconciler) buildDesiredNginxDataWithProxies() (map[string]string, error) {
+func (c *OperatorConfigMapReconciler) buildDesiredNginxDataWithProxies(ossl *ocstlsv1.OpenSSLConfig) (map[string]string, error) {
+	nginxConf, err := console.GenerateNginxRootConf(ossl)
+	if err != nil {
+		return nil, err
+	}
 	out := map[string]string{
 		// Root config is mandatory for nginx to start. Proxy configs (per client) are optional.
-		"nginx.conf": console.GetNginxRootConf(),
+		"nginx.conf": nginxConf,
 	}
 
 	if c.operatorConfigMap.Data != nil {
@@ -941,11 +951,11 @@ func (c *OperatorConfigMapReconciler) buildDesiredNginxDataWithProxies() (map[st
 		}
 	}
 
-	err := c.computeDesiredProxyConfigByKey(out)
+	err = c.computeDesiredProxyConfigByKey(out, ossl)
 	return out, err
 }
 
-func (c *OperatorConfigMapReconciler) computeDesiredProxyConfigByKey(out map[string]string) error {
+func (c *OperatorConfigMapReconciler) computeDesiredProxyConfigByKey(out map[string]string, ossl *ocstlsv1.OpenSSLConfig) error {
 	extList := &corev1.ConfigMapList{}
 	if err := c.list(extList,
 		client.InNamespace(c.OperatorNamespace),
@@ -962,7 +972,7 @@ func (c *OperatorConfigMapReconciler) computeDesiredProxyConfigByKey(out map[str
 		if err != nil {
 			return fmt.Errorf("parse endpoints ConfigMap %s: %w", client.ObjectKeyFromObject(cm), err)
 		}
-		content, err := c.buildS3EndpointProxyConfigForClient(uniqueIdentifier, endpoints)
+		content, err := c.buildS3EndpointProxyConfigForClient(uniqueIdentifier, endpoints, ossl)
 		if err != nil {
 			return err
 		}
@@ -990,7 +1000,7 @@ func parseEndpointConfigs(data map[string]string) (map[string]s3EndpointConfig, 
 	return out, nil
 }
 
-func (c *OperatorConfigMapReconciler) buildS3EndpointProxyConfigForClient(uniqueIdentifier string, endpoints map[string]s3EndpointConfig) (string, error) {
+func (c *OperatorConfigMapReconciler) buildS3EndpointProxyConfigForClient(uniqueIdentifier string, endpoints map[string]s3EndpointConfig, ossl *ocstlsv1.OpenSSLConfig) (string, error) {
 	if len(endpoints) == 0 {
 		return "", nil
 	}
@@ -1045,6 +1055,7 @@ func (c *OperatorConfigMapReconciler) buildS3EndpointProxyConfigForClient(unique
 			endpointURL,
 			endpointHost,
 			certsPath,
+			ossl,
 		)
 		if err != nil {
 			return "", fmt.Errorf("failed to build proxy config for %q: %w", exposeAs, err)

--- a/internal/controller/operatorconfigmap_controller_test.go
+++ b/internal/controller/operatorconfigmap_controller_test.go
@@ -413,7 +413,7 @@ func TestBuildS3EndpointProxyConfigForClient(t *testing.T) {
 				WithRuntimeObjects(secret).
 				Build()
 
-			content, buildErr := r.buildS3EndpointProxyConfigForClient("client-1", tt.endpoints)
+			content, buildErr := r.buildS3EndpointProxyConfigForClient("client-1", tt.endpoints, nil)
 			if tt.expectErr {
 				assert.Error(t, buildErr)
 			} else {
@@ -475,14 +475,17 @@ func TestBuildDesiredNginxDataWithProxies(t *testing.T) {
 				WithRuntimeObjects(labeledCM).
 				Build()
 
-			out, err := r.buildDesiredNginxDataWithProxies()
+			expectedNginxConf, nginxErr := console.GenerateNginxRootConf(nil)
+			assert.NoError(t, nginxErr)
+
+			out, err := r.buildDesiredNginxDataWithProxies(nil)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "parse endpoints ConfigMap")
-				assert.Equal(t, console.GetNginxRootConf(), out["nginx.conf"])
+				assert.Equal(t, expectedNginxConf, out["nginx.conf"])
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, map[string]string{"nginx.conf": console.GetNginxRootConf()}, out)
+				assert.Equal(t, map[string]string{"nginx.conf": expectedNginxConf}, out)
 			}
 		})
 	}

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	consolev1 "github.com/openshift/api/console/v1"
+	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,8 +31,13 @@ var (
 //go:embed nginx_proxy.tmpl
 var nginxProxyConf string
 
-//go:embed nginx_root.conf
+//go:embed nginx_root.tmpl
 var nginxRootConf string
+
+var (
+	nginxRootTmpl  = template.Must(template.New("nginxRootConf").Parse(nginxRootConf))
+	nginxProxyTmpl = template.Must(template.New("nginxProxyConf").Parse(nginxProxyConf))
+)
 
 func GetService(port int32, namespace string) *apiv1.Service {
 	return &apiv1.Service{
@@ -85,33 +91,69 @@ func GetConsolePlugin(consolePort int32, serviceNamespace string) *consolev1.Con
 	}
 }
 
-func GetNginxRootConf() string {
-	return nginxRootConf
+type tlsTemplateData struct {
+	Protocol     string
+	Ciphers      string
+	Ciphersuites string
+	Groups       string
 }
 
-func GetNginxProxyConf(uniqueIdentifier, exposeAs, endpointURL, endpointHost, certsPath string) (string, error) {
-	type nginxProxyConfData struct {
-		UniqueIdentifier string
-		ExposeAs         string
-		EndpointURL      string
-		EndpointHost     string
-		CertsPath        string
+func newTLSTemplateData(ossl *ocstlsv1.OpenSSLConfig) tlsTemplateData {
+	if ossl == nil {
+		return tlsTemplateData{}
 	}
+	var data tlsTemplateData
+	data.Protocol = ossl.Protocol
+	if len(ossl.Ciphers) > 0 {
+		joined := strings.Join(ossl.Ciphers, ":")
+		if ossl.Protocol == string(ocstlsv1.VersionTLS1_3) {
+			data.Ciphersuites = joined
+		} else {
+			data.Ciphers = joined
+		}
+	}
+	if len(ossl.Groups) > 0 {
+		data.Groups = strings.Join(ossl.Groups, ":")
+	}
+	return data
+}
 
-	data := nginxProxyConfData{
-		UniqueIdentifier: uniqueIdentifier,
-		ExposeAs:         exposeAs,
-		EndpointURL:      endpointURL,
-		EndpointHost:     endpointHost,
-		CertsPath:        certsPath,
-	}
-
-	t, err := template.New("nginxProxyConf").Parse(nginxProxyConf)
-	if err != nil {
-		return "", err
-	}
+func GenerateNginxRootConf(ossl *ocstlsv1.OpenSSLConfig) (string, error) {
 	var sb strings.Builder
-	if err := t.Execute(&sb, data); err != nil {
+	if err := nginxRootTmpl.Execute(&sb, newTLSTemplateData(ossl)); err != nil {
+		return "", fmt.Errorf("failed to render nginx root config: %w", err)
+	}
+	return sb.String(), nil
+}
+
+func GetNginxProxyConf(uniqueIdentifier, exposeAs, endpointURL, endpointHost, certsPath string, ossl *ocstlsv1.OpenSSLConfig) (string, error) {
+	type nginxProxyConfData struct {
+		UniqueIdentifier    string
+		ExposeAs            string
+		EndpointURL         string
+		EndpointHost        string
+		CertsPath           string
+		ProxySSLProtocol    string
+		ProxySSLCiphers     string
+		ProxySSLCiphersuites string
+		ProxySSLGroups      string
+	}
+
+	tls := newTLSTemplateData(ossl)
+	data := nginxProxyConfData{
+		UniqueIdentifier:    uniqueIdentifier,
+		ExposeAs:            exposeAs,
+		EndpointURL:         endpointURL,
+		EndpointHost:        endpointHost,
+		CertsPath:           certsPath,
+		ProxySSLProtocol:    tls.Protocol,
+		ProxySSLCiphers:     tls.Ciphers,
+		ProxySSLCiphersuites: tls.Ciphersuites,
+		ProxySSLGroups:      tls.Groups,
+	}
+
+	var sb strings.Builder
+	if err := nginxProxyTmpl.Execute(&sb, data); err != nil {
 		return "", err
 	}
 	return sb.String(), nil

--- a/pkg/console/console_test.go
+++ b/pkg/console/console_test.go
@@ -1,0 +1,120 @@
+package console
+
+import (
+	"testing"
+
+	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNginxProxyConf(t *testing.T) {
+	tests := []struct {
+		name             string
+		ossl             *ocstlsv1.OpenSSLConfig
+		expectedIncludes []string
+		expectedExcludes []string
+	}{
+		{
+			name:             "nil config produces no proxy TLS directives",
+			ossl:             nil,
+			expectedExcludes: []string{"proxy_ssl_protocols", "proxy_ssl_ciphers", "proxy_ssl_conf_command"},
+		},
+		{
+			name: "TLS 1.3 uses proxy_ssl_conf_command Ciphersuites",
+			ossl: &ocstlsv1.OpenSSLConfig{
+				Protocol: "TLSv1.3",
+				Ciphers:  []string{"TLS_AES_128_GCM_SHA256"},
+				Groups:   []string{"X25519MLKEM768"},
+			},
+			expectedIncludes: []string{
+				"proxy_ssl_protocols TLSv1.3;",
+				"proxy_ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256;",
+				"proxy_ssl_conf_command Groups X25519MLKEM768;",
+			},
+			expectedExcludes: []string{
+				"proxy_ssl_ciphers",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetNginxProxyConf("client-1", "noobaaS3", "https://s3.example.com", "s3.example.com", "/etc/pki/tls/certs/ca-bundle.crt", tt.ossl)
+			assert.NoError(t, err)
+			for _, expected := range tt.expectedIncludes {
+				assert.Contains(t, result, expected)
+			}
+			for _, excluded := range tt.expectedExcludes {
+				assert.NotContains(t, result, excluded)
+			}
+		})
+	}
+}
+
+func TestGenerateNginxRootConf(t *testing.T) {
+	tests := []struct {
+		name             string
+		ossl             *ocstlsv1.OpenSSLConfig
+		expectedIncludes []string
+		expectedExcludes []string
+	}{
+		{
+			name: "nil config produces no TLS directives",
+			ossl: nil,
+			expectedIncludes: []string{
+				"ssl_certificate_key /var/serving-cert/tls.key;",
+				"listen       9001 ssl;",
+			},
+			expectedExcludes: []string{
+				"ssl_protocols",
+				"ssl_ciphers",
+				"ssl_conf_command",
+			},
+		},
+		{
+			name: "TLS 1.3 uses ssl_conf_command Ciphersuites",
+			ossl: &ocstlsv1.OpenSSLConfig{
+				Protocol: "TLSv1.3",
+				Ciphers:  []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+				Groups:   []string{"X25519MLKEM768", "prime256v1"},
+			},
+			expectedIncludes: []string{
+				"ssl_protocols TLSv1.3;",
+				"ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384;",
+				"ssl_conf_command Groups X25519MLKEM768:prime256v1;",
+				"ssl_certificate_key /var/serving-cert/tls.key;",
+			},
+			expectedExcludes: []string{
+				"ssl_ciphers",
+			},
+		},
+		{
+			name: "TLS 1.2 with ciphers uses ssl_ciphers",
+			ossl: &ocstlsv1.OpenSSLConfig{
+				Protocol: "TLSv1.2",
+				Ciphers:  []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+			},
+			expectedIncludes: []string{
+				"ssl_protocols TLSv1.2;",
+				"ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256;",
+			},
+			expectedExcludes: []string{
+				"ssl_conf_command Ciphersuites",
+				"ssl_conf_command Groups",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GenerateNginxRootConf(tt.ossl)
+			assert.NoError(t, err)
+			for _, expected := range tt.expectedIncludes {
+				assert.Contains(t, result, expected)
+			}
+			for _, excluded := range tt.expectedExcludes {
+				assert.NotContains(t, result, excluded)
+			}
+		})
+	}
+}

--- a/pkg/console/nginx_proxy.tmpl
+++ b/pkg/console/nginx_proxy.tmpl
@@ -21,4 +21,16 @@ location /{{.UniqueIdentifier}}/{{.ExposeAs}}/ {
     proxy_ssl_verify on;
     proxy_ssl_server_name on;
     proxy_ssl_trusted_certificate {{.CertsPath}};
+    {{- if .ProxySSLProtocol}}
+    proxy_ssl_protocols {{.ProxySSLProtocol}};
+    {{- end}}
+    {{- if .ProxySSLCiphersuites}}
+    proxy_ssl_conf_command Ciphersuites {{.ProxySSLCiphersuites}};
+    {{- end}}
+    {{- if .ProxySSLCiphers}}
+    proxy_ssl_ciphers {{.ProxySSLCiphers}};
+    {{- end}}
+    {{- if .ProxySSLGroups}}
+    proxy_ssl_conf_command Groups {{.ProxySSLGroups}};
+    {{- end}}
 }

--- a/pkg/console/nginx_root.tmpl
+++ b/pkg/console/nginx_root.tmpl
@@ -102,6 +102,18 @@ http {
         listen       [::]:9001 ssl;
         ssl_certificate /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
+        {{- if .Protocol}}
+        ssl_protocols {{.Protocol}};
+        {{- end}}
+        {{- if .Ciphersuites}}
+        ssl_conf_command Ciphersuites {{.Ciphersuites}};
+        {{- end}}
+        {{- if .Ciphers}}
+        ssl_ciphers {{.Ciphers}};
+        {{- end}}
+        {{- if .Groups}}
+        ssl_conf_command Groups {{.Groups}};
+        {{- end}}
 
         location / {
             # Rate/connection limits.


### PR DESCRIPTION
## Summary
- Wire the `ocs-client-operator-console` nginx server to read TLS settings from the `TLSProfile` CRD and inject `ssl_protocols`, `ssl_ciphers`, and `ssl_conf_command Groups` directives into the nginx ConfigMap
- Add a watch on `TLSProfile` in `OperatorConfigMapReconciler.SetupWithManager()` so nginx config is regenerated when the TLS profile changes
- Add `features.operators.openshift.io/tls-profiles: "true"` CSV annotation

## Changes
- `pkg/console/nginx_root.conf`: add `%s` placeholder for TLS directive injection
- `pkg/console/console.go`: replace `GetNginxRootConf()` with `GenerateNginxConf(ossl)` + `buildTLSDirectives()` 
- `internal/controller/operatorconfigmap_controller.go`: fetch `TLSProfile` in `ensureConsolePlugin()`, resolve OpenSSL config for domain `ocs.openshift.io` / server `client-console`, pass to nginx config generation; add TLSProfile watch with name/namespace/generation predicates
- `pkg/console/console_test.go`: unit tests for `GenerateNginxConf` (nil, TLS 1.3 full, protocol-only)
- CSV template + bundle: add `tls-profiles` feature annotation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/console/...` passes (new + existing tests)
- [x] `go test -run 'TestBuildDesiredNginxDataWithProxies' ./internal/controller/...` passes
- [x] `make bundle` regenerates cleanly

Ref: [RHSTOR-8685](https://redhat.atlassian.net/browse/RHSTOR-8685)