### PR TITLE
NO-ISSUE: [release-4.16] bump csi-addons OLM dependency to 0.9.1

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,4 +2,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: csi-addons
-      version: 0.8.0
+      version: 0.9.1

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -2,4 +2,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: csi-addons
-      version: 0.8.0
+      version: 0.9.1

--- a/hack/make-bundle-vars.mk
+++ b/hack/make-bundle-vars.mk
@@ -49,7 +49,7 @@ IMAGE_TAG ?= latest
 IMAGE_NAME ?= ocs-client-operator
 BUNDLE_IMAGE_NAME ?= $(IMAGE_NAME)-bundle
 CSI_ADDONS_BUNDLE_IMAGE_NAME ?= k8s-bundle
-CSI_ADDONS_BUNDLE_IMAGE_TAG ?= v0.8.0
+CSI_ADDONS_BUNDLE_IMAGE_TAG ?= v0.9.1
 CATALOG_IMAGE_NAME ?= $(IMAGE_NAME)-catalog
 
 OCS_CLIENT_CONSOLE_IMG_NAME ?= ocs-client-console
@@ -99,7 +99,7 @@ endif
 
 # csi-addons dependencies
 CSI_ADDONS_PACKAGE_NAME ?= csi-addons
-CSI_ADDONS_PACKAGE_VERSION ?= 0.8.0
+CSI_ADDONS_PACKAGE_VERSION ?= 0.9.1
 
 ## CSI driver images
 # The following variables define the default CSI container images to deploy


### PR DESCRIPTION
## Summary
- Bump the OLM package dependency on `csi-addons` from `0.8.0` to `0.9.1`.
- Update `CSI_ADDONS_BUNDLE_IMAGE_TAG` to `v0.9.1` so catalog builds pull `quay.io/csiaddons/k8s-bundle:v0.9.1`.

## Why
`csi-addons` `0.8.0` still pulls `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`. That image is no longer available after the GCR shutdown, which causes `ImagePullBackOff` on `csi-addons-controller-manager` and has been failing ocs-operator CI on `release-4.16` for a long time.

`csi-addons` `v0.9.1` uses `quay.io/brancz/kube-rbac-proxy` instead, so it installs cleanly.