### PR TITLE
Add NetworkPolicy for ocs-client-operator-console operand

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -209,6 +209,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - objectbucket.io
           resources:
           - objectbucketclaims

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -169,6 +169,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - objectbucket.io
   resources:
   - objectbucketclaims

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -332,6 +332,7 @@ func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=operatorconfigs,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=drivers,verbs=get;list;update;create;watch;delete
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;update;delete
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile


### PR DESCRIPTION
Phase 1: Add operand NetworkPolicy via Go reconciliation.

Creates a NetworkPolicy for the ocs-client-operator-console pod allowing ingress from openshift-console on port 9001 (HTTPS ConsolePlugin backend). Egress is unrestricted.

Excluded components:
- storageclient-status-reporter: CronJob with no custom pod labels and no listening ports; NetworkPolicy not applicable.
- ocs-client-operator-controller-manager: operator pod NetworkPolicy will be added in Phase 2.

Ref: [HPSTRAT-104](https://redhat.atlassian.net/browse/HPSTRAT-104)