### PR TITLE
RHSTOR-8737: Reconcile client console network policy

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -208,6 +208,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
           - objectbucket.io
           resources:
           - objectbucketclaims

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -168,6 +168,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - objectbucket.io
   resources:
   - objectbucketclaims

--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -315,6 +315,7 @@ func (c *OperatorConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;watch;create;patch;update;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;create;update
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=*
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch;update;delete
@@ -874,6 +875,18 @@ func (c *OperatorConfigMapReconciler) ensureConsolePlugin() error {
 
 	if err != nil {
 		c.log.Error(err, "failed to create/update service for console")
+		return err
+	}
+
+	consoleNetworkPolicy := console.GetNetworkPolicy(c.OperatorNamespace)
+	err = c.createOrUpdate(consoleNetworkPolicy, func() error {
+		resourceVersion := consoleNetworkPolicy.ResourceVersion
+		console.GetNetworkPolicy(c.OperatorNamespace).DeepCopyInto(consoleNetworkPolicy)
+		consoleNetworkPolicy.ResourceVersion = resourceVersion
+		return controllerutil.SetControllerReference(c.consoleDeployment, consoleNetworkPolicy, c.Scheme)
+	})
+	if err != nil {
+		c.log.Error(err, "failed to create/update network policy for console")
 		return err
 	}
 

--- a/internal/controller/operatorconfigmap_controller_test.go
+++ b/internal/controller/operatorconfigmap_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"testing"
@@ -10,12 +11,17 @@ import (
 	"github.com/red-hat-storage/ocs-client-operator/pkg/utils"
 
 	configv1 "github.com/openshift/api/config/v1"
+	consolev1 "github.com/openshift/api/console/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -76,6 +82,34 @@ func newFakeConfigMapReconciler(t *testing.T) OperatorConfigMapReconciler {
 func newFakeClientBuilder(scheme *runtime.Scheme) *fake.ClientBuilder {
 	return fake.NewClientBuilder().
 		WithScheme(scheme)
+}
+
+func TestEnsureConsolePluginCreatesOwnedNetworkPolicy(t *testing.T) {
+	r := newFakeConfigMapReconciler(t)
+	assert.NoError(t, consolev1.AddToScheme(r.Scheme))
+	r.ctx = context.Background()
+	r.ConsolePort = 9001
+	r.operatorConfigMap = &corev1.ConfigMap{}
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: console.DeploymentName, Namespace: testNamespace, UID: types.UID("deployment-uid"),
+	}}
+	r.Client = newFakeClientBuilder(r.Scheme).WithObjects(deployment).Build()
+
+	assert.NoError(t, r.ensureConsolePlugin())
+
+	policy := &networkingv1.NetworkPolicy{}
+	key := client.ObjectKey{Name: console.DeploymentName, Namespace: testNamespace}
+	assert.NoError(t, r.Client.Get(context.Background(), key, policy))
+	assert.True(t, metav1.IsControlledBy(policy, deployment))
+	assert.Equal(t, console.GetNetworkPolicy(testNamespace).Spec, policy.Spec)
+
+	policy.Spec.PolicyTypes = nil
+	policy.OwnerReferences = nil
+	assert.NoError(t, r.Client.Update(context.Background(), policy))
+	assert.NoError(t, r.ensureConsolePlugin())
+	assert.NoError(t, r.Client.Get(context.Background(), key, policy))
+	assert.True(t, metav1.IsControlledBy(policy, deployment))
+	assert.Equal(t, console.GetNetworkPolicy(testNamespace).Spec, policy.Spec)
 }
 
 func TestGetImageSet(t *testing.T) {

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -8,6 +8,7 @@ import (
 
 	consolev1 "github.com/openshift/api/console/v1"
 	apiv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -57,6 +58,35 @@ func GetService(port int32, namespace string) *apiv1.Service {
 			Selector: map[string]string{
 				AppNameLabelKey: DeploymentName,
 			},
+		},
+	}
+}
+
+func GetNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	protocol := apiv1.ProtocolTCP
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{AppNameLabelKey: DeploymentName}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": "openshift-console",
+					}},
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"app":       "console",
+						"component": "ui",
+					}},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: &protocol,
+					Port:     &intstr.IntOrString{IntVal: 9001},
+				}},
+			}},
 		},
 	}
 }

--- a/pkg/console/networkpolicy_test.go
+++ b/pkg/console/networkpolicy_test.go
@@ -1,0 +1,35 @@
+package console
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestGetNetworkPolicy(t *testing.T) {
+	protocol := corev1.ProtocolTCP
+	expected := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: testNamespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{AppNameLabelKey: DeploymentName}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-console"}},
+					PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "console", "component": "ui"}},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{Protocol: &protocol, Port: &intstr.IntOrString{IntVal: 9001}}},
+			}},
+		},
+	}
+
+	if actual := GetNetworkPolicy(testNamespace); !reflect.DeepEqual(actual, expected) {
+		t.Errorf("unexpected network policy: %#v", actual)
+	}
+}
+
+const testNamespace = "test-ns"


### PR DESCRIPTION
## Summary
- reconcile the Client Console NetworkPolicy with its Deployment
- restrict TCP/9001 ingress to OpenShift Console UI pods
- leave egress unrestricted for dynamic S3 endpoint proxying

red-hat-storage/odf-operator#896
red-hat-storage/odf-multicluster-orchestrator#490
