### PR TITLE
fix: disable csi-addons for nvmeof driver

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -808,6 +808,7 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 				nvmeofDriver.Spec.ControllerPlugin = &csiopv1.ControllerPluginSpec{}
 			}
 			nvmeofDriver.Spec.ControllerPlugin.HostNetwork = ptr.To(useHostNetForNvmeofCtrlPlugin)
+			nvmeofDriver.Spec.DeployCsiAddons = new(bool)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile nvmeof driver: %v", err)


### PR DESCRIPTION
The NVMeoF CSI driver does not implement CSI-Addons. Setting `DeployCsiAddons=false` on the `NVMeoF` Driver CR prevents the `ceph-csi-operator` from deploying the `csi-addons` sidecar, which was crash-looping due to a missing csi-addons.sock socket.