### PR TITLE
controllers: disable fencing for kubeVirt clusters

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -675,6 +675,7 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 			driverSpecDefaults.ControllerPlugin.ContainerExtraArgs = csiExtraArgs
 			driverSpecDefaults.NodePlugin.ContainerExtraArgs = csiExtraArgs
 		}
+		driverSpecDefaults.EnableFencing = ptr.To(!c.shouldDisableAutoFencing())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile csi operator config: %v", err)
@@ -1491,6 +1492,19 @@ func (c *OperatorConfigMapReconciler) reconcileRbdSMSSpecConfigMap() error {
 		return fmt.Errorf("failed to reconcile snapshot metadata spec ConfigMap: %w", err)
 	}
 	return nil
+}
+
+func (c *OperatorConfigMapReconciler) shouldDisableAutoFencing() bool {
+	infra := &configv1.Infrastructure{}
+	infra.Name = "cluster"
+	if err := c.get(infra); err != nil {
+		c.log.Info("failed to fetch infrastructure resource", "error", err)
+		return true
+	}
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType {
+		return true
+	}
+	return false
 }
 
 func adjustPluginCpuResourcesForIbmZ(resources any, adjustFactor float64) {


### PR DESCRIPTION
disable auto fencing for nodes tainted with out of service taint, for kubevirt clusters that led to IO being stopped for base clusters as well.

Fixes: [DFBUGS-9233](https://redhat.atlassian.net/browse/DFBUGS-9233)