### PR TITLE
Disable VolumeGroupSnapshot for NVMe-oF CSI driver

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -810,6 +810,7 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 			}
 			nvmeofDriver.Spec.ControllerPlugin.HostNetwork = ptr.To(useHostNetForNvmeofCtrlPlugin)
 			nvmeofDriver.Spec.DeployCsiAddons = new(bool)
+			nvmeofDriver.Spec.SnapshotPolicy = csiopv1.VolumeSnapshotSnapshotPolicy
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile nvmeof driver: %v", err)


### PR DESCRIPTION
The `NVMe-oF` CSI driver does not implement the `GroupController` gRPC service. When the default SnapshotPolicy (`volumeGroupSnapshot`) is applied, the snapshotter sidecar starts `VolumeGroupSnapshot` informers that never sync, blocking all snapshot processing.

Override SnapshotPolicy to `volumeSnapshot` for the NVMe-oF driver, keeping regular snapshots enabled while disabling `VolumeGroupSnapshot`.

Related: https://github.com/ceph/ceph-csi-operator/pull/579