### PR TITLE
fix incorrect watches ballooning memory usage

### DIFF
--- a/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-client-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Storage
     console.openshift.io/plugins: '["odf-client-console"]'
     containerImage: quay.io/ocs-dev/ocs-client-operator:latest
-    createdAt: "2026-08-11T11:01:57Z"
+    createdAt: "2026-08-20T06:01:42Z"
     description: OpenShift Data Foundation client operator enables consumption of
       storage services from a remote centralized OpenShift Data Foundation provider
       cluster.
@@ -428,6 +428,7 @@ spec:
       deployments:
       - label:
           app: ocs-client-operator
+          app.kubernetes.io/part-of: ocs-client-operator
           control-plane: controller-manager
         name: ocs-client-operator-controller-manager
         spec:
@@ -507,6 +508,7 @@ spec:
                   secretName: ocs-client-metrics-cert-secret
       - label:
           app.kubernetes.io/name: ocs-client-operator-console
+          app.kubernetes.io/part-of: ocs-client-operator
         name: ocs-client-operator-console
         spec:
           replicas: 1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -379,7 +380,13 @@ func buildCacheAvailableCRDs(
 			LabelSelector: noobaaLabelSelector,
 		},
 	}
+	csvExcludeCopied, err := labels.NewRequirement("olm.copiedFrom", selection.DoesNotExist, nil)
+	if err != nil {
+		setupLog.Error(err, "failed to create CSV label requirement")
+		os.Exit(1)
+	}
 	cacheAvailableCrd := cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
 		ByObject: map[client.Object]cache.ByObject{
 			&admrv1.ValidatingWebhookConfiguration{}: {
 				// only cache our validation webhook
@@ -390,6 +397,19 @@ func buildCacheAvailableCRDs(
 			},
 			&corev1.Secret{}: {
 				Namespaces: configMapAndSecretCacheByNamespace,
+			},
+			&appsv1.Deployment{}: {
+				Namespaces: map[string]cache.Config{
+					operatorNamespace: {},
+				},
+				// this label is set on client console and operator deployments as part of csv
+				Label: labels.SelectorFromSet(labels.Set{"app.kubernetes.io/part-of": "ocs-client-operator"}),
+			},
+			&opv1a1.ClusterServiceVersion{}: {
+				Namespaces: map[string]cache.Config{
+					operatorNamespace: {},
+				},
+				Label: labels.NewSelector().Add(*csvExcludeCopied),
 			},
 		},
 		DefaultNamespaces: defaultNamespaces,

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: console
+  labels:
+    app.kubernetes.io/part-of: ocs-client-operator
 spec:
   replicas: 1
   selector:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app: ocs-client-operator
+    app.kubernetes.io/part-of: ocs-client-operator
 spec:
   selector:
     matchLabels:

--- a/internal/controller/crds_presence_controller.go
+++ b/internal/controller/crds_presence_controller.go
@@ -41,6 +41,7 @@ func (r *CrdsPresenceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}),
 				utils.EventTypePredicate(true, false, true, false),
 			),
+			builder.OnlyMetadata,
 		).
 		Complete(r)
 }

--- a/internal/controller/storageclient_controller.go
+++ b/internal/controller/storageclient_controller.go
@@ -522,15 +522,13 @@ func (r *storageClientReconcile) setupObjectBucketWatch() error {
 		return nil
 	}
 
-	crd := &extv1.CustomResourceDefinition{}
+	crd := &metav1.PartialObjectMetadata{}
+	crd.SetGroupVersionKind(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
 	crd.Name = ObjectBucketCrdName
 	if err := r.get(crd); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 	if crd.UID == "" {
-		return nil
-	}
-	if !crdEstablished(crd) {
 		return nil
 	}
 
@@ -1281,16 +1279,4 @@ func (r *storageClientReconcile) getOperatorVersion() (string, error) {
 		return "", fmt.Errorf("failed to get csv: %v", err)
 	}
 	return csv.Spec.Version.String(), nil
-}
-
-// crdEstablished reports whether the CRD is served by the apiserver (status.conditions Established=True).
-// A CRD object can exist before the REST mapping for its resource is available.
-func crdEstablished(crd *extv1.CustomResourceDefinition) bool {
-	for i := range crd.Status.Conditions {
-		c := crd.Status.Conditions[i]
-		if c.Type == extv1.Established && c.Status == extv1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
all crd's along with specs were being silently cached due to reading full crd for finding the established field which isn't required to establish a watch, this saves a lot of memory and is regression.

in huge clusters with many OSDs, all the deployments were being cached adding more weight along with CSVs which have operators installed in AllNamespaces and tighten them.

Trimming out managedfields also would save non-trivial amount of memory on huge clusters.

Below are some of the numbers (averaged) based on profiling (including overhead):
Deployment: ~200KB
CRD (full): ~130KB
PV: ~12KB

Extrapolating:
[DFBUGS-4532](https://redhat.atlassian.net/browse/DFBUGS-4532): 200M from PVs, 100M from Deps, this was before CRD regr and that would add 45M. With the fix the PV memory would be dominating.
[DFBUGS-9939](https://redhat.atlassian.net/browse/DFBUGS-9939): 80M from CRDs (regr), don't have full data to calculate other overheads.

Overall the CRD regression is the dominating factor and remaining fixes helps huge clusters (ie, 100s of deployments and 1000s of PVs) and so we are optimizing for the general case to leave the niche be directly configurable on subscription itself.

Please note these numbers are based on 10-12 profiles but still may not be accurate, however these are on higher side.