### PR TITLE
DFBUGS-10111: [release-4.22] csi: disable setting vgs policy

### DIFF
--- a/internal/controller/operatorconfigmap_controller.go
+++ b/internal/controller/operatorconfigmap_controller.go
@@ -643,9 +643,9 @@ func (c *OperatorConfigMapReconciler) reconcileDelegatedCSI(storageClients *v1al
 		}
 		driverSpecDefaults.ImageSet = &corev1.LocalObjectReference{Name: cmName}
 		driverSpecDefaults.ClusterName = ptr.To(string(clusterVersion.Spec.ClusterID))
-		if c.AvailableCrds[VolumeGroupSnapshotClassCrdName] {
-			driverSpecDefaults.SnapshotPolicy = csiopv1.VolumeGroupSnapshotPolicy
-		}
+		//if c.AvailableCrds[VolumeGroupSnapshotClassCrdName] {
+		//	driverSpecDefaults.SnapshotPolicy = csiopv1.VolumeGroupSnapshotPolicy
+		//}
 		if cniNetworkAnnotationValue != "" {
 			if driverSpecDefaults.ControllerPlugin.Annotations == nil {
 				driverSpecDefaults.ControllerPlugin.Annotations = map[string]string{}


### PR DESCRIPTION
Upstream volumegroupsnapshotclass creation is disabled in odf-4.22. Ocp 5.0 has VGSC v1 enabled. Ocs-client-operator detects this CRD and sets `SnapshotPolicy` to `volumeGroupSnapshot`, which enables the csi-snapshotter sidecar to watch for public VGSC resources as they are available.
On an ocp 5.0 cluster, this results in errors in the `csi-snapshotter` container as it searches for v1beta2 api. 

The fix is commenting the check so that the default SnapshotPolicy (volumeSnapshot) is set.

Ref: https://redhat.atlassian.net/browse/DFBUGS-10111 